### PR TITLE
feat: implement CLIEngine adapter (Backend → Engine) (#65)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git *)",
+      "Bash(make *)",
+      "Bash(go test *)",
+      "Bash(go build *)",
+      "Bash(go vet *)",
+      "Bash(go mod *)",
+      "Bash(go doc *)",
+      "Bash(go version *)",
+      "Bash(golangci-lint *)",
+      "Bash(govulncheck *)",
+      "Bash(gh pr *)",
+      "Bash(gh issue *)",
+      "Bash(gh run *)"
+    ]
+  }
+}

--- a/engine/cli/doc.go
+++ b/engine/cli/doc.go
@@ -1,6 +1,26 @@
 // Package cli provides a CLI subprocess transport adapter for agentrun engines.
 //
-// This package defines the consumer-side interfaces (Spawner, Parser, Resumer,
-// Streamer, InputFormatter) and a generic CLIEngine that orchestrates subprocess
-// lifecycle. Concrete backends (claude, opencode) implement these interfaces.
+// A Backend implements [Spawner] and [Parser] to define how subprocesses are
+// launched and how their stdout is parsed into [agentrun.Message] values.
+// Optional capabilities ([Resumer], [Streamer], [InputFormatter]) are discovered
+// via type assertion at runtime.
+//
+// [NewEngine] wraps a Backend into an [agentrun.Engine]. The returned [Engine]
+// manages subprocess lifecycle, message pumping, graceful shutdown (SIGTERM then
+// SIGKILL), and the Resumer subprocess-replacement pattern for multi-turn sessions.
+//
+// # Platform Support
+//
+// The [Engine] and process types use Unix signals (SIGTERM, SIGKILL) for
+// subprocess lifecycle management and are not available on Windows. The interface
+// types ([Backend], [Spawner], [Parser], [Resumer], [Streamer], [InputFormatter])
+// and option types are available on all platforms.
+//
+// # Consumer Obligations
+//
+// Callers must either drain the [agentrun.Process.Output] channel to completion
+// or call [agentrun.Process.Stop] to release subprocess resources. Failing to
+// do so may leave the subprocess running and leak goroutines.
+//
+// Concrete backends (claude, opencode) implement the Backend interface.
 package cli

--- a/engine/cli/engine_test.go
+++ b/engine/cli/engine_test.go
@@ -1,0 +1,1067 @@
+//go:build !windows
+
+package cli_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dmora/agentrun"
+	"github.com/dmora/agentrun/engine/cli"
+)
+
+const (
+	binEcho  = "echo"
+	binSleep = "sleep"
+	binBash  = "bash"
+	binCat   = "cat"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func testCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+func tempDir(t *testing.T) string {
+	t.Helper()
+	return t.TempDir()
+}
+
+// drain collects all messages from a process output channel.
+func drain(p agentrun.Process) []agentrun.Message {
+	msgs := make([]agentrun.Message, 0, 8)
+	for m := range p.Output() {
+		msgs = append(msgs, m)
+	}
+	return msgs
+}
+
+// textParser parses each line as a text message.
+func textParser(line string) (agentrun.Message, error) {
+	return agentrun.Message{Type: agentrun.MessageText, Content: line}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Stub backends (function-field injection)
+// ---------------------------------------------------------------------------
+
+type testBackend struct {
+	spawnFn func(agentrun.Session) (string, []string)
+	parseFn func(string) (agentrun.Message, error)
+}
+
+func (b *testBackend) SpawnArgs(s agentrun.Session) (string, []string) { return b.spawnFn(s) }
+func (b *testBackend) ParseLine(line string) (agentrun.Message, error) { return b.parseFn(line) }
+
+type testResumerBackend struct {
+	testBackend
+	resumeFn func(agentrun.Session, string) (string, []string, error)
+}
+
+func (b *testResumerBackend) ResumeArgs(s agentrun.Session, prompt string) (string, []string, error) {
+	return b.resumeFn(s, prompt)
+}
+
+type testStreamerBackend struct {
+	testBackend
+	streamFn func(agentrun.Session) (string, []string)
+	formatFn func(string) ([]byte, error)
+}
+
+func (b *testStreamerBackend) StreamArgs(s agentrun.Session) (string, []string) {
+	return b.streamFn(s)
+}
+
+func (b *testStreamerBackend) FormatInput(msg string) ([]byte, error) {
+	return b.formatFn(msg)
+}
+
+type testStreamerOnlyBackend struct {
+	testBackend
+	streamFn func(agentrun.Session) (string, []string)
+}
+
+func (b *testStreamerOnlyBackend) StreamArgs(s agentrun.Session) (string, []string) {
+	return b.streamFn(s)
+}
+
+// echoBackend returns a backend that spawns "echo" with session.Prompt
+// and parses each line as a text message.
+func echoBackend() *testBackend {
+	return &testBackend{
+		spawnFn: func(s agentrun.Session) (string, []string) {
+			return binEcho, []string{s.Prompt}
+		},
+		parseFn: textParser,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Compile-time checks
+// ---------------------------------------------------------------------------
+
+var _ agentrun.Engine = (*cli.Engine)(nil)
+
+// ---------------------------------------------------------------------------
+// Validate tests
+// ---------------------------------------------------------------------------
+
+func TestValidate_Found(t *testing.T) {
+	b := &testBackend{
+		spawnFn: func(_ agentrun.Session) (string, []string) { return binEcho, nil },
+		parseFn: textParser,
+	}
+	eng := cli.NewEngine(b)
+	if err := eng.Validate(); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestValidate_NotFound(t *testing.T) {
+	b := &testBackend{
+		spawnFn: func(_ agentrun.Session) (string, []string) {
+			return "nonexistent-binary-xyz-999", nil
+		},
+		parseFn: textParser,
+	}
+	eng := cli.NewEngine(b)
+	err := eng.Validate()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, agentrun.ErrUnavailable) {
+		t.Fatalf("expected ErrUnavailable, got %v", err)
+	}
+}
+
+func TestValidate_PanicRecovery(t *testing.T) {
+	b := &testBackend{
+		spawnFn: func(_ agentrun.Session) (string, []string) { panic("boom") },
+		parseFn: textParser,
+	}
+	eng := cli.NewEngine(b)
+	err := eng.Validate()
+	if err == nil {
+		t.Fatal("expected error from panic")
+	}
+	if !errors.Is(err, agentrun.ErrUnavailable) {
+		t.Fatalf("expected ErrUnavailable, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "panicked") {
+		t.Fatalf("expected panic message, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Start tests
+// ---------------------------------------------------------------------------
+
+func TestStart_Echo(t *testing.T) {
+	eng := cli.NewEngine(echoBackend())
+	ctx := testCtx(t)
+
+	p, err := eng.Start(ctx, agentrun.Session{
+		CWD:    tempDir(t),
+		Prompt: "hello",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	msgs := drain(p)
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if msgs[0].Content != "hello" {
+		t.Fatalf("expected 'hello', got %q", msgs[0].Content)
+	}
+	if err := p.Wait(); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+}
+
+func TestStart_MultiLine(t *testing.T) {
+	b := &testBackend{
+		spawnFn: func(_ agentrun.Session) (string, []string) {
+			return "printf", []string{"line1\nline2\nline3\n"}
+		},
+		parseFn: textParser,
+	}
+	eng := cli.NewEngine(b)
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t)})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	msgs := drain(p)
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages, got %d: %v", len(msgs), msgs)
+	}
+}
+
+func TestStart_OptionOverrides(t *testing.T) {
+	tests := []struct {
+		name    string
+		session agentrun.Session
+		opt     agentrun.Option
+		extract func(agentrun.Session) string
+		want    string
+	}{
+		{
+			name:    "Prompt",
+			session: agentrun.Session{Prompt: "original"},
+			opt:     agentrun.WithPrompt("override"),
+			extract: func(s agentrun.Session) string { return s.Prompt },
+			want:    "override",
+		},
+		{
+			name:    "Model",
+			session: agentrun.Session{Model: "original-model"},
+			opt:     agentrun.WithModel("override-model"),
+			extract: func(s agentrun.Session) string { return s.Model },
+			want:    "override-model",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured string
+			b := &testBackend{
+				spawnFn: func(s agentrun.Session) (string, []string) {
+					captured = tt.extract(s)
+					return binEcho, []string{"x"}
+				},
+				parseFn: textParser,
+			}
+			tt.session.CWD = tempDir(t)
+			eng := cli.NewEngine(b)
+			p, err := eng.Start(testCtx(t), tt.session, tt.opt)
+			if err != nil {
+				t.Fatalf("Start: %v", err)
+			}
+			drain(p)
+			_ = p.Wait()
+
+			if captured != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, captured)
+			}
+		})
+	}
+}
+
+func TestStart_InvalidCWD_Empty(t *testing.T) {
+	eng := cli.NewEngine(echoBackend())
+	_, err := eng.Start(testCtx(t), agentrun.Session{CWD: ""})
+	if err == nil {
+		t.Fatal("expected error for empty CWD")
+	}
+}
+
+func TestStart_InvalidCWD_Relative(t *testing.T) {
+	eng := cli.NewEngine(echoBackend())
+	_, err := eng.Start(testCtx(t), agentrun.Session{CWD: "relative/path"})
+	if err == nil {
+		t.Fatal("expected error for relative CWD")
+	}
+}
+
+func TestStart_InvalidCWD_NonExistent(t *testing.T) {
+	eng := cli.NewEngine(echoBackend())
+	_, err := eng.Start(testCtx(t), agentrun.Session{CWD: "/nonexistent/path/xyz"})
+	if err == nil {
+		t.Fatal("expected error for non-existent CWD")
+	}
+}
+
+func TestStart_ContextCanceled(t *testing.T) {
+	b := &testBackend{
+		spawnFn: func(_ agentrun.Session) (string, []string) {
+			return binSleep, []string{"60"}
+		},
+		parseFn: textParser,
+	}
+	eng := cli.NewEngine(b)
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t)})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Stop immediately to ensure no leaked process.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = p.Stop(ctx)
+}
+
+// ---------------------------------------------------------------------------
+// Output tests
+// ---------------------------------------------------------------------------
+
+func TestOutput_ClosedAfterExit(t *testing.T) {
+	eng := cli.NewEngine(echoBackend())
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t), Prompt: "x"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// range terminates when channel closes.
+	count := 0
+	for range p.Output() {
+		count++
+	}
+	if count != 1 {
+		t.Fatalf("expected 1, got %d", count)
+	}
+}
+
+func TestOutput_DrainAfterStop(t *testing.T) {
+	b := &testBackend{
+		spawnFn: func(_ agentrun.Session) (string, []string) {
+			return binSleep, []string{"60"}
+		},
+		parseFn: textParser,
+	}
+	eng := cli.NewEngine(b)
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t)})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = p.Stop(ctx)
+
+	// Output channel should be closed after Stop returns.
+	drain(p)
+}
+
+// ---------------------------------------------------------------------------
+// Stop tests
+// ---------------------------------------------------------------------------
+
+func TestStop_Graceful(t *testing.T) {
+	b := &testBackend{
+		spawnFn: func(_ agentrun.Session) (string, []string) {
+			return binSleep, []string{"60"}
+		},
+		parseFn: textParser,
+	}
+	eng := cli.NewEngine(b)
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t)})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := p.Stop(ctx); !errors.Is(err, agentrun.ErrTerminated) {
+		t.Fatalf("expected ErrTerminated, got %v", err)
+	}
+}
+
+func TestStop_ForceKill(t *testing.T) {
+	b := &testBackend{
+		spawnFn: func(_ agentrun.Session) (string, []string) {
+			// Trap SIGTERM and ignore it — forces SIGKILL path.
+			return binBash, []string{"-c", `trap "" TERM; sleep 60`}
+		},
+		parseFn: textParser,
+	}
+	eng := cli.NewEngine(b, cli.WithGracePeriod(200*time.Millisecond))
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t)})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Give bash time to set up trap.
+	time.Sleep(100 * time.Millisecond)
+
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = p.Stop(ctx)
+	elapsed := time.Since(start)
+
+	// Should have been killed within grace period + some margin.
+	if elapsed > 2*time.Second {
+		t.Fatalf("Stop took too long: %v", elapsed)
+	}
+}
+
+func TestStop_Idempotent(t *testing.T) {
+	eng := cli.NewEngine(echoBackend())
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t), Prompt: "x"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	drain(p)
+
+	ctx := testCtx(t)
+	_ = p.Stop(ctx)
+	_ = p.Stop(ctx) // second call must not panic
+}
+
+func TestStop_AfterNaturalExit(t *testing.T) {
+	eng := cli.NewEngine(echoBackend())
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t), Prompt: "x"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	_ = p.Wait()
+
+	// Stop on an already-exited process.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = p.Stop(ctx)
+}
+
+func TestStop_ContextDeadline(t *testing.T) {
+	b := &testBackend{
+		spawnFn: func(_ agentrun.Session) (string, []string) {
+			return binBash, []string{"-c", `trap "" TERM; sleep 60`}
+		},
+		parseFn: textParser,
+	}
+	eng := cli.NewEngine(b, cli.WithGracePeriod(30*time.Second))
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t)})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Short context deadline triggers SIGKILL before grace period.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_ = p.Stop(ctx)
+	elapsed := time.Since(start)
+
+	if elapsed > 2*time.Second {
+		t.Fatalf("Stop took too long: %v", elapsed)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Wait / Err tests
+// ---------------------------------------------------------------------------
+
+func TestWait_CleanExit(t *testing.T) {
+	eng := cli.NewEngine(echoBackend())
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t), Prompt: "x"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	drain(p)
+	if err := p.Wait(); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestWait_ErrorExit(t *testing.T) {
+	b := &testBackend{
+		spawnFn: func(_ agentrun.Session) (string, []string) {
+			return binBash, []string{"-c", "exit 42"}
+		},
+		parseFn: textParser,
+	}
+	eng := cli.NewEngine(b)
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t)})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	drain(p)
+	if err := p.Wait(); err == nil {
+		t.Fatal("expected non-nil error for exit 42")
+	}
+}
+
+func TestWait_OutputNotDrained(t *testing.T) {
+	// Verify no deadlock when output channel is not drained.
+	eng := cli.NewEngine(echoBackend())
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t), Prompt: "x"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Don't drain — Wait should still return because output buffer > 0.
+	done := make(chan error, 1)
+	go func() { done <- p.Wait() }()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Wait deadlocked without draining output")
+	}
+}
+
+func TestErr_BeforeClose(t *testing.T) {
+	b := &testBackend{
+		spawnFn: func(_ agentrun.Session) (string, []string) {
+			return binSleep, []string{"60"}
+		},
+		parseFn: textParser,
+	}
+	eng := cli.NewEngine(b)
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t)})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Err should be nil while process is running.
+	if err := p.Err(); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = p.Stop(ctx)
+}
+
+func TestErr_AfterStop(t *testing.T) {
+	b := &testBackend{
+		spawnFn: func(_ agentrun.Session) (string, []string) {
+			return binSleep, []string{"60"}
+		},
+		parseFn: textParser,
+	}
+	eng := cli.NewEngine(b)
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t)})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = p.Stop(ctx)
+
+	if err := p.Err(); !errors.Is(err, agentrun.ErrTerminated) {
+		t.Fatalf("expected ErrTerminated, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Send tests
+// ---------------------------------------------------------------------------
+
+func TestSend_Stdin(t *testing.T) {
+	b := &testStreamerBackend{
+		testBackend: testBackend{
+			spawnFn: func(_ agentrun.Session) (string, []string) {
+				return binCat, nil
+			},
+			parseFn: textParser,
+		},
+		streamFn: func(_ agentrun.Session) (string, []string) {
+			return binCat, nil
+		},
+		formatFn: func(msg string) ([]byte, error) {
+			return []byte(msg + "\n"), nil
+		},
+	}
+	eng := cli.NewEngine(b)
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t)})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if err := p.Send(testCtx(t), "hello stdin"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	// Read one message.
+	msg := <-p.Output()
+	if msg.Content != "hello stdin" {
+		t.Fatalf("expected 'hello stdin', got %q", msg.Content)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = p.Stop(ctx)
+}
+
+func TestSend_Resume(t *testing.T) {
+	b := &testResumerBackend{
+		testBackend: testBackend{
+			spawnFn: func(_ agentrun.Session) (string, []string) {
+				// Long-lived: outputs "initial" then waits for SIGTERM.
+				return binBash, []string{"-c", "echo initial; sleep 60"}
+			},
+			parseFn: textParser,
+		},
+		resumeFn: func(_ agentrun.Session, prompt string) (string, []string, error) {
+			return binEcho, []string{prompt}, nil
+		},
+	}
+	eng := cli.NewEngine(b)
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t)})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// First message from initial spawn.
+	msg := <-p.Output()
+	if msg.Content != "initial" {
+		t.Fatalf("expected 'initial', got %q", msg.Content)
+	}
+
+	// Send triggers Resumer replacement (kills old, spawns new).
+	if err := p.Send(testCtx(t), "resumed"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	// Second message from replacement subprocess.
+	msg = <-p.Output()
+	if msg.Content != "resumed" {
+		t.Fatalf("expected 'resumed', got %q", msg.Content)
+	}
+
+	drain(p)
+	if err := p.Wait(); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+}
+
+func TestSend_NoCapability(t *testing.T) {
+	eng := cli.NewEngine(echoBackend())
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t), Prompt: "x"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	drain(p)
+
+	err = p.Send(testCtx(t), "hello")
+	if err == nil {
+		t.Fatal("expected error for no capability")
+	}
+}
+
+func TestSend_AfterStop(t *testing.T) {
+	b := &testBackend{
+		spawnFn: func(_ agentrun.Session) (string, []string) {
+			return binSleep, []string{"60"}
+		},
+		parseFn: textParser,
+	}
+	eng := cli.NewEngine(b)
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t)})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = p.Stop(ctx)
+
+	if err := p.Send(testCtx(t), "hello"); !errors.Is(err, agentrun.ErrTerminated) {
+		t.Fatalf("expected ErrTerminated, got %v", err)
+	}
+}
+
+func TestSend_Stdin_ConcurrentWithStop(t *testing.T) {
+	b := &testStreamerBackend{
+		testBackend: testBackend{
+			spawnFn: func(_ agentrun.Session) (string, []string) {
+				return binCat, nil
+			},
+			parseFn: textParser,
+		},
+		streamFn: func(_ agentrun.Session) (string, []string) {
+			return binCat, nil
+		},
+		formatFn: func(msg string) ([]byte, error) {
+			return []byte(msg + "\n"), nil
+		},
+	}
+	eng := cli.NewEngine(b)
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t)})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := range 100 {
+			if err := p.Send(testCtx(t), fmt.Sprintf("msg-%d", i)); err != nil {
+				return // expected once Stop is called
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		time.Sleep(10 * time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = p.Stop(ctx)
+	}()
+	wg.Wait()
+}
+
+func TestSend_Resume_ContextCanceled(t *testing.T) {
+	b := &testResumerBackend{
+		testBackend: testBackend{
+			spawnFn: func(_ agentrun.Session) (string, []string) {
+				// Trap SIGTERM so the old process doesn't exit quickly.
+				return binBash, []string{"-c", `trap "" TERM; echo initial; sleep 60`}
+			},
+			parseFn: textParser,
+		},
+		resumeFn: func(_ agentrun.Session, _ string) (string, []string, error) {
+			return binSleep, []string{"60"}, nil
+		},
+	}
+	eng := cli.NewEngine(b)
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t)})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Read initial message.
+	<-p.Output()
+
+	// Give bash time to set up SIGTERM trap.
+	time.Sleep(100 * time.Millisecond)
+
+	// Send with already-canceled context — forces ctx.Done path in replaceSubprocess.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = p.Send(ctx, "should-fail")
+	if err == nil {
+		t.Fatal("expected error from canceled context")
+	}
+
+	// Process should be cleanly finishable — Stop must not deadlock.
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer stopCancel()
+	_ = p.Stop(stopCtx)
+}
+
+func TestSend_StreamerWithoutFormatter(t *testing.T) {
+	b := &testStreamerOnlyBackend{
+		testBackend: testBackend{
+			spawnFn: func(_ agentrun.Session) (string, []string) {
+				return binCat, nil
+			},
+			parseFn: textParser,
+		},
+		streamFn: func(_ agentrun.Session) (string, []string) {
+			return binCat, nil
+		},
+	}
+	eng := cli.NewEngine(b)
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t)})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Backend is Streamer (stdin pipe open) but has no InputFormatter.
+	err = p.Send(testCtx(t), "hello")
+	if err == nil {
+		t.Fatal("expected error when Streamer lacks InputFormatter")
+	}
+	if !strings.Contains(err.Error(), "InputFormatter") {
+		t.Fatalf("expected InputFormatter error, got %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = p.Stop(ctx)
+}
+
+// ---------------------------------------------------------------------------
+// ReadLoop behavior tests
+// ---------------------------------------------------------------------------
+
+func TestReadLoop_SkipLine(t *testing.T) {
+	b := &testBackend{
+		spawnFn: func(_ agentrun.Session) (string, []string) {
+			return "printf", []string{"keep\nskip\nkeep2\n"}
+		},
+		parseFn: func(line string) (agentrun.Message, error) {
+			if line == "skip" {
+				return agentrun.Message{}, cli.ErrSkipLine
+			}
+			return agentrun.Message{Type: agentrun.MessageText, Content: line}, nil
+		},
+	}
+	eng := cli.NewEngine(b)
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t)})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	msgs := drain(p)
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages (skip filtered), got %d", len(msgs))
+	}
+	if msgs[0].Content != "keep" || msgs[1].Content != "keep2" {
+		t.Fatalf("unexpected messages: %v", msgs)
+	}
+}
+
+func TestReadLoop_ParseError(t *testing.T) {
+	b := &testBackend{
+		spawnFn: func(_ agentrun.Session) (string, []string) {
+			return binEcho, []string{"bad"}
+		},
+		parseFn: func(_ string) (agentrun.Message, error) {
+			return agentrun.Message{}, errors.New("parse failed")
+		},
+	}
+	eng := cli.NewEngine(b)
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t)})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	msgs := drain(p)
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 error message, got %d", len(msgs))
+	}
+	if msgs[0].Type != agentrun.MessageError {
+		t.Fatalf("expected MessageError, got %v", msgs[0].Type)
+	}
+	if !strings.Contains(msgs[0].Content, "parse failed") {
+		t.Fatalf("expected 'parse failed' in content, got %q", msgs[0].Content)
+	}
+}
+
+func TestReadLoop_Timestamp(t *testing.T) {
+	before := time.Now()
+	eng := cli.NewEngine(echoBackend())
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t), Prompt: "x"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	msgs := drain(p)
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if msgs[0].Timestamp.Before(before) {
+		t.Fatalf("timestamp %v is before start time %v", msgs[0].Timestamp, before)
+	}
+}
+
+func TestReadLoop_RawLine(t *testing.T) {
+	eng := cli.NewEngine(echoBackend())
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t), Prompt: "hello"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	msgs := drain(p)
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1, got %d", len(msgs))
+	}
+	if msgs[0].RawLine != "hello" {
+		t.Fatalf("expected RawLine 'hello', got %q", msgs[0].RawLine)
+	}
+}
+
+func TestReadLoop_PanicRecovery(t *testing.T) {
+	b := &testBackend{
+		spawnFn: func(_ agentrun.Session) (string, []string) {
+			return binEcho, []string{"trigger"}
+		},
+		parseFn: func(_ string) (agentrun.Message, error) {
+			panic("parser exploded")
+		},
+	}
+	eng := cli.NewEngine(b)
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t)})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Process should terminate with error, not crash the host.
+	err = p.Wait()
+	if err == nil {
+		t.Fatal("expected error from panic")
+	}
+	if !strings.Contains(err.Error(), "parser panic") {
+		t.Fatalf("expected 'parser panic' in error, got %v", err)
+	}
+}
+
+func TestReadLoop_ScannerOverflow(t *testing.T) {
+	b := &testBackend{
+		spawnFn: func(_ agentrun.Session) (string, []string) {
+			// Generate a line longer than 256 bytes (no trailing newline).
+			return binBash, []string{"-c", fmt.Sprintf("head -c %d /dev/zero | tr '\\0' 'A'", 512)}
+		},
+		parseFn: textParser,
+	}
+	// Set tiny scanner buffer to trigger overflow.
+	eng := cli.NewEngine(b, cli.WithScannerBuffer(256))
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t)})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	msgs := drain(p)
+	hasError := false
+	for _, m := range msgs {
+		if m.Type == agentrun.MessageError && strings.Contains(m.Content, "scanner") {
+			hasError = true
+			break
+		}
+	}
+	if !hasError {
+		t.Fatalf("expected scanner error message, got %v", msgs)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Session deep-copy test
+// ---------------------------------------------------------------------------
+
+func TestStart_SessionDeepCopy(t *testing.T) {
+	var capturedOpts map[string]string
+	b := &testBackend{
+		spawnFn: func(s agentrun.Session) (string, []string) {
+			capturedOpts = s.Options
+			return binEcho, []string{"x"}
+		},
+		parseFn: textParser,
+	}
+	eng := cli.NewEngine(b)
+
+	origOpts := map[string]string{"key": "original"}
+	p, err := eng.Start(testCtx(t), agentrun.Session{
+		CWD:     tempDir(t),
+		Options: origOpts,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	drain(p)
+	_ = p.Wait()
+
+	// Mutating original should not affect captured.
+	origOpts["key"] = "mutated"
+	if capturedOpts["key"] != "original" {
+		t.Fatalf("session was not deep-copied: captured=%q", capturedOpts["key"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency tests
+// ---------------------------------------------------------------------------
+
+func TestConcurrent_StopAndRead(t *testing.T) {
+	b := &testBackend{
+		spawnFn: func(_ agentrun.Session) (string, []string) {
+			return binBash, []string{"-c", "while true; do echo line; sleep 0.01; done"}
+		},
+		parseFn: textParser,
+	}
+	eng := cli.NewEngine(b)
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t)})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Read and stop concurrently.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		drain(p)
+	}()
+	go func() {
+		defer wg.Done()
+		time.Sleep(50 * time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = p.Stop(ctx)
+	}()
+	wg.Wait()
+}
+
+func TestConcurrent_EngineStart(t *testing.T) {
+	eng := cli.NewEngine(echoBackend())
+	dir := tempDir(t)
+
+	var wg sync.WaitGroup
+	for i := range 5 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			p, err := eng.Start(testCtx(t), agentrun.Session{
+				CWD:    dir,
+				Prompt: fmt.Sprintf("msg-%d", i),
+			})
+			if err != nil {
+				t.Errorf("Start: %v", err)
+				return
+			}
+			drain(p)
+			_ = p.Wait()
+		}()
+	}
+	wg.Wait()
+}
+
+// ---------------------------------------------------------------------------
+// Options tests
+// ---------------------------------------------------------------------------
+
+func TestOptions_Defaults(t *testing.T) {
+	eng := cli.NewEngine(echoBackend())
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t), Prompt: "x"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	drain(p)
+	if err := p.Wait(); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+}
+
+func TestOptions_Custom(t *testing.T) {
+	eng := cli.NewEngine(echoBackend(),
+		cli.WithOutputBuffer(10),
+		cli.WithScannerBuffer(4096),
+		cli.WithGracePeriod(1*time.Second),
+	)
+	p, err := eng.Start(testCtx(t), agentrun.Session{CWD: tempDir(t), Prompt: "x"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	drain(p)
+	if err := p.Wait(); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CWD as file (not directory) test
+// ---------------------------------------------------------------------------
+
+func TestStart_CWD_IsFile(t *testing.T) {
+	dir := tempDir(t)
+	filePath := filepath.Join(dir, "afile.txt")
+	if err := os.WriteFile(filePath, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	eng := cli.NewEngine(echoBackend())
+	_, err := eng.Start(testCtx(t), agentrun.Session{CWD: filePath})
+	if err == nil {
+		t.Fatal("expected error when CWD is a file")
+	}
+}

--- a/engine/cli/interfaces.go
+++ b/engine/cli/interfaces.go
@@ -59,6 +59,14 @@ type Streamer interface {
 	StreamArgs(session agentrun.Session) (binary string, args []string)
 }
 
+// Backend is the minimum interface a CLI backend must implement.
+// Optional capabilities (Resumer, Streamer, InputFormatter) are
+// discovered via type assertion at runtime.
+type Backend interface {
+	Spawner
+	Parser
+}
+
 // InputFormatter encodes user messages for delivery to a subprocess stdin
 // pipe. InputFormatter is optional — the CLIEngine discovers it via type
 // assertion independently of Streamer:

--- a/engine/cli/options.go
+++ b/engine/cli/options.go
@@ -1,0 +1,70 @@
+package cli
+
+import "time"
+
+// Default engine configuration values.
+const (
+	defaultOutputBuffer  = 100
+	defaultScannerBuffer = 1 << 20 // 1 MB
+	defaultGracePeriod   = 5 * time.Second
+)
+
+// EngineOptions holds resolved construction-time configuration for a CLI engine.
+// Use NewEngine with EngineOption functions to customize these values.
+type EngineOptions struct {
+	// OutputBuffer is the channel buffer size for process output messages.
+	OutputBuffer int
+
+	// ScannerBuffer is the maximum line size in bytes for the stdout scanner.
+	ScannerBuffer int
+
+	// GracePeriod is the duration to wait after SIGTERM before sending SIGKILL.
+	GracePeriod time.Duration
+}
+
+// EngineOption configures an Engine at construction time.
+type EngineOption func(*EngineOptions)
+
+// WithOutputBuffer sets the channel buffer size for process output messages.
+// Values <= 0 are ignored.
+func WithOutputBuffer(size int) EngineOption {
+	return func(o *EngineOptions) {
+		if size > 0 {
+			o.OutputBuffer = size
+		}
+	}
+}
+
+// WithScannerBuffer sets the maximum line size in bytes for the stdout scanner.
+// Values <= 0 are ignored.
+func WithScannerBuffer(size int) EngineOption {
+	return func(o *EngineOptions) {
+		if size > 0 {
+			o.ScannerBuffer = size
+		}
+	}
+}
+
+// WithGracePeriod sets the duration to wait after SIGTERM before sending SIGKILL.
+// Values <= 0 are ignored.
+func WithGracePeriod(d time.Duration) EngineOption {
+	return func(o *EngineOptions) {
+		if d > 0 {
+			o.GracePeriod = d
+		}
+	}
+}
+
+func resolveEngineOptions(opts ...EngineOption) EngineOptions {
+	o := EngineOptions{
+		OutputBuffer:  defaultOutputBuffer,
+		ScannerBuffer: defaultScannerBuffer,
+		GracePeriod:   defaultGracePeriod,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&o)
+		}
+	}
+	return o
+}

--- a/engine/cli/process.go
+++ b/engine/cli/process.go
@@ -1,0 +1,382 @@
+//go:build !windows
+
+package cli
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/dmora/agentrun"
+)
+
+// capabilities holds resolved optional interfaces for a process.
+// Resolved once in Engine.Start to eliminate process→engine back-references.
+type capabilities struct {
+	resumer   Resumer
+	streamer  Streamer
+	formatter InputFormatter
+}
+
+func resolveCapabilities(backend Backend) capabilities {
+	var caps capabilities
+	if r, ok := backend.(Resumer); ok {
+		caps.resumer = r
+	}
+	if s, ok := backend.(Streamer); ok {
+		caps.streamer = s
+	}
+	if f, ok := backend.(InputFormatter); ok {
+		caps.formatter = f
+	}
+	return caps
+}
+
+// signalProcess sends sig to a process, returning nil if the process
+// has already exited (os.ErrProcessDone).
+func signalProcess(proc *os.Process, sig os.Signal) error {
+	err := proc.Signal(sig)
+	if errors.Is(err, os.ErrProcessDone) {
+		return nil
+	}
+	return err
+}
+
+// process implements agentrun.Process for CLI subprocess sessions.
+type process struct {
+	backend Backend
+	caps    capabilities
+	session agentrun.Session
+	opts    EngineOptions
+
+	output chan agentrun.Message
+
+	mu         sync.Mutex
+	cmd        *exec.Cmd
+	stdin      io.WriteCloser
+	replacing  bool
+	cancelRead context.CancelFunc
+
+	cmdDone chan struct{} // buffered(1), signaled by every readLoop defer
+	done    chan struct{} // closed exactly once by finish()
+	termErr error         // set by finish(), read after done closes
+
+	stopping   atomic.Bool
+	stopOnce   sync.Once
+	finishOnce sync.Once
+}
+
+var _ agentrun.Process = (*process)(nil)
+
+// newProcess creates and starts a process with its initial readLoop.
+func newProcess(
+	backend Backend,
+	caps capabilities,
+	session agentrun.Session,
+	opts EngineOptions,
+	cmd *exec.Cmd,
+	stdin io.WriteCloser,
+	stdout io.ReadCloser,
+) *process {
+	readCtx, cancelRead := context.WithCancel(context.Background())
+
+	p := &process{
+		backend:    backend,
+		caps:       caps,
+		session:    session,
+		opts:       opts,
+		output:     make(chan agentrun.Message, opts.OutputBuffer),
+		cmd:        cmd,
+		stdin:      stdin,
+		cancelRead: cancelRead,
+		cmdDone:    make(chan struct{}, 1),
+		done:       make(chan struct{}),
+	}
+	go p.readLoop(readCtx, stdout)
+	return p
+}
+
+// Output returns the channel for receiving messages from the subprocess.
+func (p *process) Output() <-chan agentrun.Message {
+	return p.output
+}
+
+// Send transmits a user message to the subprocess.
+func (p *process) Send(ctx context.Context, message string) error {
+	// Reject sends on stopped/done process.
+	select {
+	case <-p.done:
+		return agentrun.ErrTerminated
+	default:
+	}
+	if p.stopping.Load() {
+		return agentrun.ErrTerminated
+	}
+
+	// Path 1: stdin pipe (Streamer mode).
+	if p.stdin != nil {
+		return p.sendStdin(message)
+	}
+
+	// Path 2: Resumer (subprocess replacement).
+	if p.caps.resumer != nil {
+		return p.replaceSubprocess(ctx, message)
+	}
+
+	return errors.New("cli: backend supports neither Streamer nor Resumer for Send")
+}
+
+// sendStdin formats and writes a message to the subprocess stdin pipe.
+func (p *process) sendStdin(message string) error {
+	if p.caps.formatter == nil {
+		return errors.New("cli: streaming mode but backend does not implement InputFormatter")
+	}
+	data, err := p.caps.formatter.FormatInput(message)
+	if err != nil {
+		return fmt.Errorf("cli: format input: %w", err)
+	}
+	p.mu.Lock()
+	stdin := p.stdin
+	p.mu.Unlock()
+	if stdin == nil {
+		return agentrun.ErrTerminated
+	}
+	if _, err := stdin.Write(data); err != nil {
+		return fmt.Errorf("cli: write stdin: %w", err)
+	}
+	return nil
+}
+
+// Stop terminates the subprocess. Safe to call multiple times.
+// Blocks until the output channel is closed.
+func (p *process) Stop(ctx context.Context) error {
+	p.stopOnce.Do(func() {
+		p.stopping.Store(true)
+
+		p.mu.Lock()
+		if p.stdin != nil {
+			_ = p.stdin.Close() // Best-effort: pipe may already be closed.
+		}
+		cancelRead := p.cancelRead
+		cmd := p.cmd
+		p.mu.Unlock()
+
+		// Unblock readLoop if stuck on channel send.
+		cancelRead()
+
+		// Send SIGTERM for graceful termination.
+		_ = signalProcess(cmd.Process, syscall.SIGTERM)
+
+		// Wait for readLoop to finish, with grace period.
+		select {
+		case <-p.cmdDone:
+		case <-time.After(p.opts.GracePeriod):
+			_ = signalProcess(cmd.Process, os.Kill)
+			<-p.cmdDone
+		case <-ctx.Done():
+			_ = signalProcess(cmd.Process, os.Kill)
+			<-p.cmdDone
+		}
+	})
+
+	// Block until finish() completes (output channel closed).
+	<-p.done
+	return p.termErr
+}
+
+// Wait blocks until the session ends naturally.
+func (p *process) Wait() error {
+	<-p.done
+	return p.termErr
+}
+
+// Err returns the terminal error, or nil if still running.
+func (p *process) Err() error {
+	select {
+	case <-p.done:
+		return p.termErr
+	default:
+		return nil
+	}
+}
+
+// finish sets the terminal error and closes output+done channels.
+// Called exactly once via sync.Once.
+func (p *process) finish(err error) {
+	p.finishOnce.Do(func() {
+		p.termErr = err
+		close(p.output)
+		close(p.done)
+	})
+}
+
+// readLoop is the goroutine that reads subprocess stdout and pumps messages.
+func (p *process) readLoop(ctx context.Context, stdout io.ReadCloser) {
+	var panicErr error
+	var scanErr error
+
+	defer func() {
+		if r := recover(); r != nil {
+			_ = signalProcess(p.cmd.Process, os.Kill)
+			panicErr = fmt.Errorf("cli: parser panic: %v", r)
+		}
+
+		p.mu.Lock()
+		cmd := p.cmd
+		p.mu.Unlock()
+
+		waitErr := cmd.Wait()
+		switch {
+		case panicErr != nil:
+			waitErr = panicErr
+		case scanErr != nil:
+			waitErr = fmt.Errorf("cli: scanner: %w", scanErr)
+		}
+		if p.stopping.Load() {
+			waitErr = agentrun.ErrTerminated
+		}
+
+		p.mu.Lock()
+		replacing := p.replacing
+		p.mu.Unlock()
+
+		if !replacing {
+			p.finish(waitErr)
+		}
+
+		// Always signal cmdDone so Stop/replaceSubprocess can proceed.
+		p.cmdDone <- struct{}{}
+	}()
+
+	scanErr = p.scanLines(ctx, stdout)
+	if scanErr != nil {
+		// Surface scanner error as a message before termination.
+		msg := agentrun.Message{
+			Type:      agentrun.MessageError,
+			Content:   fmt.Sprintf("cli: scanner: %v", scanErr),
+			Timestamp: time.Now(),
+		}
+		select {
+		case p.output <- msg:
+		default:
+			// Channel full; error preserved in scanErr, surfaced via finish().
+		}
+		p.mu.Lock()
+		_ = signalProcess(p.cmd.Process, os.Kill)
+		p.mu.Unlock()
+	}
+}
+
+// scanLines reads lines from stdout and sends parsed messages to the output channel.
+func (p *process) scanLines(ctx context.Context, stdout io.ReadCloser) error {
+	scanner := bufio.NewScanner(stdout)
+	initCap := min(4096, p.opts.ScannerBuffer)
+	scanner.Buffer(make([]byte, 0, initCap), p.opts.ScannerBuffer)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		msg, err := p.backend.ParseLine(line)
+		if errors.Is(err, ErrSkipLine) {
+			continue
+		}
+		if err != nil {
+			msg = agentrun.Message{
+				Type:    agentrun.MessageError,
+				Content: fmt.Sprintf("cli: parse: %v", err),
+			}
+		}
+		if msg.Timestamp.IsZero() {
+			msg.Timestamp = time.Now()
+		}
+		if msg.RawLine == "" {
+			msg.RawLine = line
+		}
+
+		select {
+		case p.output <- msg:
+		case <-ctx.Done():
+			return nil
+		}
+	}
+	return scanner.Err()
+}
+
+// replaceSubprocess performs the Resumer subprocess-replacement pattern.
+func (p *process) replaceSubprocess(ctx context.Context, message string) error {
+	binary, args, err := p.caps.resumer.ResumeArgs(p.session, message)
+	if err != nil {
+		return fmt.Errorf("cli: resume args: %w", err)
+	}
+	resolvedBinary, err := exec.LookPath(binary)
+	if err != nil {
+		return fmt.Errorf("%w: %s: %w", agentrun.ErrUnavailable, binary, err)
+	}
+
+	// Signal old process to terminate.
+	p.mu.Lock()
+	p.replacing = true
+	oldCancel := p.cancelRead
+	if p.stdin != nil {
+		_ = p.stdin.Close() // Best-effort: pipe may already be closed.
+	}
+	oldCmd := p.cmd
+	p.mu.Unlock()
+
+	oldCancel()
+	_ = signalProcess(oldCmd.Process, syscall.SIGTERM)
+
+	// Wait for old readLoop to finish.
+	select {
+	case <-p.cmdDone:
+	case <-ctx.Done():
+		_ = signalProcess(oldCmd.Process, os.Kill)
+		<-p.cmdDone
+		p.failReplacement(ctx.Err())
+		return ctx.Err()
+	}
+
+	return p.spawnReplacement(resolvedBinary, args)
+}
+
+// failReplacement handles cleanup when subprocess replacement fails.
+// It resets the replacing flag, finishes the process with the given error,
+// and signals cmdDone so a subsequent Stop() call won't deadlock.
+func (p *process) failReplacement(err error) {
+	p.mu.Lock()
+	p.replacing = false
+	p.mu.Unlock()
+	p.finish(err)
+	select {
+	case p.cmdDone <- struct{}{}:
+	default:
+	}
+}
+
+// spawnReplacement starts a new subprocess and readLoop after a Resumer swap.
+func (p *process) spawnReplacement(binary string, args []string) error {
+	cmd, stdin, stdout, err := spawnCmd(binary, args, p.session.CWD, p.caps.streamer != nil)
+	if err != nil {
+		p.failReplacement(fmt.Errorf("cli: resume: %w", err))
+		return err
+	}
+
+	readCtx, cancelRead := context.WithCancel(context.Background())
+
+	p.mu.Lock()
+	p.cmd = cmd
+	p.stdin = stdin
+	p.cancelRead = cancelRead
+	p.replacing = false
+	p.mu.Unlock()
+
+	go p.readLoop(readCtx, stdout)
+	return nil
+}


### PR DESCRIPTION
## Summary

- Implements the core CLI subprocess engine that wires `Spawner+Parser` backends into an `agentrun.Engine`
- Manages subprocess lifecycle, message pumping, graceful shutdown (SIGTERM→SIGKILL), and the Resumer subprocess-replacement pattern for multi-turn sessions
- 35 tests with real subprocesses, race-detector clean, `make qa` green

## Key Components

| File | Purpose |
|------|---------|
| `engine.go` | `Engine`, `NewEngine`, `Validate`, `Start` — wraps Backend into agentrun.Engine |
| `process.go` | `process` implementing `agentrun.Process` — readLoop, scanLines, Send (stdin/Resumer), Stop, Wait |
| `options.go` | `EngineOptions`, `EngineOption`, `WithOutputBuffer/ScannerBuffer/GracePeriod` |
| `interfaces.go` | Added `Backend` combined interface (Spawner + Parser) |
| `doc.go` | Updated package docs with platform support and consumer obligations |
| `CLAUDE.md` | Updated architecture tree, package table, added new conventions |
| `.claude/settings.json` | Shared project permissions for Go toolchain |

## Design Decisions

- **Capabilities resolved once**: `Streamer`, `Resumer`, `InputFormatter` type-asserted at `Start()`, stored in `capabilities` struct — no repeated assertions
- **`//go:build !windows`**: Engine/process use Unix signals; interfaces and options remain cross-platform
- **`signalProcess()` helper**: All Signal/Kill calls guard against `os.ErrProcessDone`
- **`failReplacement()` helper**: Prevents Stop() deadlock when context expires during subprocess replacement
- **Scanner error preservation**: `scanErr` captured in closure, surfaced through `finish()` even when output channel is full

## Test plan

- [x] 35 tests covering: Validate, Start, Output, Stop, Wait/Err, Send (stdin + Resumer + edge cases), ReadLoop, concurrency, options
- [x] `go test -race -count=5` clean (no races, no flakes)
- [x] `make qa` green (lint, test-race, vet, vulncheck, examples-build)
- [x] Table-driven tests for option overrides (Prompt, Model)
- [x] Concurrent Send+Stop race test on Streamer backend
- [x] Context cancellation during Resumer subprocess swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)