### PR TITLE
chore: project reflection — settings, rules, docs

### DIFF
--- a/.claude/rules/design-philosophy.md
+++ b/.claude/rules/design-philosophy.md
@@ -1,0 +1,42 @@
+---
+paths:
+  - "session.go"
+  - "errors.go"
+  - "message.go"
+  - "agentrun.go"
+  - "engine/**/*.go"
+---
+
+# Design Philosophy: Root is Language, Backends are Dialect
+
+When adding or modifying constants, types, or options, apply this decision rule:
+
+> **Would this concept exist if backend X didn't exist?**
+> - **Yes** → it belongs in the root `agentrun` package.
+> - **No** → it belongs in the backend package (e.g., `engine/cli/claude/`).
+
+## Quick Reference
+
+**Root (shared vocabulary):**
+- `MessageType` constants — output vocabulary (what agents say)
+- `Option*` constants — input vocabulary (what you ask of agents)
+- `Mode`, `HITL` types — cross-cutting session controls
+- `Session.Model`, `Session.Prompt` — structural config
+
+**Backend (dialect):**
+- Wire format mapping (CLI flags, API bodies)
+- Backend-specific options (`OptionPermissionMode`, `OptionResumeID`)
+- Backend-specific permission/mode constants
+
+## Anti-Patterns
+
+- Do NOT place cross-cutting constants in a backend because only one backend exists today. Design for N backends.
+- Do NOT duplicate cross-cutting constants across backends. If two backends need the same option, it belongs in root.
+- Do NOT expand Session struct fields for every cross-cutting option. Use `Option*` constants with `Session.Options`.
+
+## Independent Control Surfaces
+
+Root options (`OptionMode`/`OptionHITL`) and backend options (`OptionPermissionMode`) are independent:
+- Root set → backend-specific option ignored
+- Root absent → backend-specific option used
+- Never combined or cascaded

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,7 @@
       "Bash(govulncheck *)",
       "Bash(gh pr *)",
       "Bash(gh issue *)",
+      "Bash(gh api *)",
       "Bash(gh run *)",
       "Bash(go run *)"
     ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,3 +93,4 @@ agentrun (interfaces)
 - **Separate examples module**: `examples/go.mod` avoids pulling example deps into library consumers
 - **Platform build constraints**: Engine implementations using OS-specific features (signals, process groups) use `//go:build !windows` on implementation files. Interface and option files remain platform-agnostic.
 - **Signal safety**: All process Signal/Kill calls use `signalProcess()` helper which handles `os.ErrProcessDone` — prevents errors on already-exited processes
+- **Cross-cutting session controls**: `Mode` (plan/act) and `HITL` (on/off) types live in root with `Valid()` methods. Root options and backend-specific options (e.g., `claude.OptionPermissionMode`) are independent control surfaces — root wins when set, backend used when absent. See `resolvePermissionFlag()` in Claude backend.


### PR DESCRIPTION
## Summary

- Add `Bash(gh api *)` permission to `.claude/settings.json` — eliminates manual approval for PR comment replies via `gh api`
- Add `.claude/rules/design-philosophy.md` — path-scoped rule that enforces the "root vs backend" decision rule when editing `session.go`, `errors.go`, `message.go`, `agentrun.go`, or `engine/**/*.go`
- Add cross-cutting session controls bullet to CLAUDE.md Key Conventions section

Also cleaned up (not in this commit, local-only):
- `settings.local.json` — removed 6 session-specific cruft entries
- `memory/MEMORY.md` — removed stale in-progress section, updated test counts, deduplicated content

## Test plan

- [x] `make qa` green
- [x] No code changes — config/docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)