### PR TITLE
chore: project reflection — fix stale docs

### DIFF
--- a/.claude/rules/design-philosophy.md
+++ b/.claude/rules/design-philosophy.md
@@ -25,7 +25,7 @@ When adding or modifying constants, types, or options, apply this decision rule:
 
 **Backend (dialect):**
 - Wire format mapping (CLI flags, API bodies)
-- Backend-specific options (`OptionPermissionMode`, `OptionResumeID`)
+- Backend-specific options (`OptionPermissionMode`)
 - Backend-specific permission/mode constants
 
 ## Anti-Patterns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ agentrun (interfaces)
 | `filter` | Composable channel middleware for message streams (Completed, Filter, ResultOnly, IsDelta) |
 | `engine/cli` | CLI subprocess engine: Backend→Engine adapter, process lifecycle, signal handling |
 | `engine/cli/claude` | Claude Code backend (all 5 cli interfaces: Spawner, Parser, Resumer, Streamer, InputFormatter) |
-| `engine/cli/opencode` | OpenCode backend (stub) |
+| `engine/cli/opencode` | OpenCode backend (Spawner, Parser, Resumer) |
 | `engine/acp` | ACP engine: JSON-RPC 2.0 persistent subprocess, multi-turn without MCP cold boot |
 | `engine/api/adk` | Google ADK API engine |
 | `enginetest` | Shared compliance test suites (RunSpawnerTests, etc.) |
@@ -102,3 +102,6 @@ agentrun (interfaces)
 - **Platform build constraints**: Engine implementations using OS-specific features (signals, process groups) use `//go:build !windows` on implementation files. Interface and option files remain platform-agnostic.
 - **Signal safety**: All process Signal/Kill calls use `signalProcess()` helper which handles `os.ErrProcessDone` — prevents errors on already-exited processes
 - **Cross-cutting session controls**: `Mode` (plan/act) and `HITL` (on/off) types live in root with `Valid()` methods. Root options and backend-specific options (e.g., `claude.OptionPermissionMode`) are independent control surfaces — root wins when set, backend used when absent. See `resolvePermissionFlag()` in Claude backend.
+- **Option parse helpers**: `ParsePositiveIntOption`, `ParseBoolOption`, `StringOption` in `session_options.go` — backends use these instead of scattered `strconv` parsing. Both typed parsers validate null bytes and return `(value, ok, error)`.
+- **RunTurn helper**: `runturn.go` encapsulates concurrent Send+drain pattern. Callers must provide a context with deadline/timeout. Safe for all engine types.
+- **Shared test infrastructure**: `testutil_test.go` contains `mockProcess` — shared across root-package test files.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -21,7 +21,7 @@ The root package (`agentrun`) defines the **language** — the shared concepts t
 | Input vocabulary | `Option*` constants | Flag/API mapping |
 | Config (structural) | `Session.Model`, `Session.Prompt` | — |
 | Config (cross-cutting) | `OptionSystemPrompt`, `OptionMaxTurns` | `--system-prompt`, `--max-turns` |
-| Config (backend-specific) | — | `OptionPermissionMode`, `OptionResumeID` |
+| Config (backend-specific) | — | `OptionPermissionMode` |
 
 ### Why Option Keys are Vocabulary
 
@@ -44,7 +44,7 @@ The root package (`agentrun`) defines the **language** — the shared concepts t
 | `OptionMaxTurns` | Yes — any agentic loop has a budget | `agentrun` | Universal loop control |
 | `OptionThinkingBudget` | Yes — any reasoning model | `agentrun` | Universal reasoning control |
 | `OptionPermissionMode` | No — Claude CLI sandboxing | `claude` | Claude-specific subprocess security |
-| `OptionResumeID` | No — Claude conversation ID | `claude` | Claude-specific session resumption |
+| `OptionResumeID` | Yes — any session can resume | `agentrun` | Universal session resumption |
 | `MessageText` | Yes — every agent produces text | `agentrun` | Universal output type |
 | `MessageThinkingDelta` | Yes — any streaming reasoning model | `agentrun` | Universal streaming output |
 | `OptionMode` | Yes — every tool has plan vs act | `agentrun` | Universal session intent |


### PR DESCRIPTION
## Summary

- Fix `OptionResumeID` listed as backend-specific in DESIGN.md and `.claude/rules/design-philosophy.md` — moved to root in PR #11
- Update OpenCode description from "stub" to full backend in CLAUDE.md
- Add new conventions: option parse helpers, RunTurn helper, shared test infrastructure

Also updated (not in this PR — auto-memory, gitignored):
- MEMORY.md: fixed stale function name, updated issue tracker, test count 475→640+, removed resolved section
- settings.local.json: removed one-off ACP debugging commands

## Test plan

- [x] Docs-only change — no code modified
- [x] `go test -race ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)