### PR TITLE
test: add enginetest/clitest compliance suite

### DIFF
--- a/.claude/rules/design-philosophy.md
+++ b/.claude/rules/design-philosophy.md
@@ -36,7 +36,7 @@ When adding or modifying constants, types, or options, apply this decision rule:
 
 ## Independent Control Surfaces
 
-Root options (`OptionMode`/`OptionHITL`) and backend options (`OptionPermissionMode`) are independent:
+Root options (`OptionMode`/`OptionHITL`) and backend options (`claude.OptionPermissionMode`, `codex.OptionSandbox`) are independent:
 - Root set → backend-specific option ignored
 - Root absent → backend-specific option used
 - Never combined or cascaded

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,19 +64,28 @@ type CLIEngine struct {
 
 This approach is simpler, more readable, and avoids build-time code generation.
 
-### enginetest/ compliance suites
+### enginetest/clitest compliance suites
 
-Backend authors prove correctness by calling shared test functions:
+Backend authors prove correctness by calling `RunBackendTests` with a factory callback. The suite discovers optional capabilities (Resumer, Streamer, InputFormatter) via type assertion:
 
 ```go
-func TestMyBackend(t *testing.T) {
-    enginetest.RunSpawnerTests(t, func() cli.Spawner {
+package mybackend_test
+
+import (
+    "testing"
+    "github.com/dmora/agentrun/engine/cli"
+    "github.com/dmora/agentrun/engine/cli/mybackend"
+    "github.com/dmora/agentrun/enginetest/clitest"
+)
+
+func TestCompliance(t *testing.T) {
+    clitest.RunBackendTests(t, func() cli.Backend {
         return mybackend.New()
     })
 }
 ```
 
-The `Run*Tests` pattern (RunSpawnerTests, RunParserTests, etc.) ensures all backends satisfy the same behavioral contract.
+Individual `RunSpawnerTests`, `RunParserTests`, and `RunResumerTests` are also exported for backends with unusual needs.
 
 ### Zero external dependencies
 
@@ -95,4 +104,4 @@ The following feedback was captured during architecture review and should be add
 - Scanner buffer size should be configurable (dropped messages = patient safety issue) — #65
 - RecoverableEngine as optional interface keeps API engines clean — #63
 - CLIOptions typed struct prevents stringly-typed contract in Session.Options — #64
-- Subprocess test helpers (SIGTERM/SIGKILL lifecycle) belong in enginetest/ — #68
+- Subprocess test helpers (SIGTERM/SIGKILL lifecycle) could be added to enginetest as engine-level compliance suites

--- a/engine/cli/claude/args_test.go
+++ b/engine/cli/claude/args_test.go
@@ -259,6 +259,19 @@ func TestSpawnArgs_SkipsNullBytes(t *testing.T) {
 	}
 }
 
+func TestSpawnArgs_ModelLeadingDash(t *testing.T) {
+	b := New()
+	_, args := b.SpawnArgs(agentrun.Session{Prompt: testPrompt, Model: "-evil"})
+	for _, a := range args {
+		if a == "--model" {
+			t.Error("--model should be omitted for leading-dash model")
+		}
+		if a == "-evil" {
+			t.Error("leading-dash model should not appear in args")
+		}
+	}
+}
+
 func TestSpawnArgs_IgnoresResumeID(t *testing.T) {
 	b := New()
 	session := agentrun.Session{

--- a/engine/cli/claude/claude.go
+++ b/engine/cli/claude/claude.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/dmora/agentrun"
 	"github.com/dmora/agentrun/engine/cli"
@@ -221,7 +222,7 @@ func appendPositiveInt(args []string, opts map[string]string, key, flag string) 
 // max-turns, and max-thinking-tokens flags based on session fields
 // and options. Invalid or null-byte-containing values are silently skipped.
 func appendSessionArgs(args []string, session agentrun.Session) []string {
-	if session.Model != "" && !jsonutil.ContainsNull(session.Model) {
+	if session.Model != "" && !jsonutil.ContainsNull(session.Model) && !strings.HasPrefix(session.Model, "-") {
 		args = append(args, "--model", session.Model)
 	}
 

--- a/engine/cli/claude/compliance_test.go
+++ b/engine/cli/claude/compliance_test.go
@@ -1,0 +1,15 @@
+package claude_test
+
+import (
+	"testing"
+
+	"github.com/dmora/agentrun/engine/cli"
+	"github.com/dmora/agentrun/engine/cli/claude"
+	"github.com/dmora/agentrun/enginetest/clitest"
+)
+
+func TestCompliance(t *testing.T) {
+	clitest.RunBackendTests(t, func() cli.Backend {
+		return claude.New()
+	})
+}

--- a/engine/cli/codex/compliance_test.go
+++ b/engine/cli/codex/compliance_test.go
@@ -1,0 +1,15 @@
+package codex_test
+
+import (
+	"testing"
+
+	"github.com/dmora/agentrun/engine/cli"
+	"github.com/dmora/agentrun/engine/cli/codex"
+	"github.com/dmora/agentrun/enginetest/clitest"
+)
+
+func TestCompliance(t *testing.T) {
+	clitest.RunBackendTests(t, func() cli.Backend {
+		return codex.New()
+	})
+}

--- a/engine/cli/opencode/compliance_test.go
+++ b/engine/cli/opencode/compliance_test.go
@@ -1,0 +1,15 @@
+package opencode_test
+
+import (
+	"testing"
+
+	"github.com/dmora/agentrun/engine/cli"
+	"github.com/dmora/agentrun/engine/cli/opencode"
+	"github.com/dmora/agentrun/enginetest/clitest"
+)
+
+func TestCompliance(t *testing.T) {
+	clitest.RunBackendTests(t, func() cli.Backend {
+		return opencode.New()
+	})
+}

--- a/engine/cli/opencode/opencode.go
+++ b/engine/cli/opencode/opencode.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"sync/atomic"
 
 	"github.com/dmora/agentrun"
@@ -178,7 +179,7 @@ func baseArgs() []string {
 // Mode, HITL, SystemPrompt, and MaxTurns are silently ignored
 // (OpenCode has no CLI flags for these).
 func appendCommonArgs(args []string, session agentrun.Session) []string {
-	if session.Model != "" && !jsonutil.ContainsNull(session.Model) {
+	if session.Model != "" && !jsonutil.ContainsNull(session.Model) && !strings.HasPrefix(session.Model, "-") {
 		args = append(args, "--model", session.Model)
 	}
 

--- a/engine/cli/opencode/opencode_test.go
+++ b/engine/cli/opencode/opencode_test.go
@@ -166,6 +166,19 @@ func TestSpawnArgs_NullByteModel(t *testing.T) {
 	}
 }
 
+func TestSpawnArgs_ModelLeadingDash(t *testing.T) {
+	b := New()
+	_, args := b.SpawnArgs(agentrun.Session{Prompt: "hi", Model: "-evil"})
+	for _, a := range args {
+		if a == "--model" {
+			t.Error("--model should be omitted for leading-dash model")
+		}
+		if a == "-evil" {
+			t.Error("leading-dash model should not appear in args")
+		}
+	}
+}
+
 func TestSpawnArgs_NullByteAgentID(t *testing.T) {
 	b := New()
 	_, args := b.SpawnArgs(agentrun.Session{

--- a/enginetest/clitest/clitest.go
+++ b/enginetest/clitest/clitest.go
@@ -1,0 +1,292 @@
+package clitest
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dmora/agentrun"
+	"github.com/dmora/agentrun/engine/cli"
+)
+
+// universalResumeID is a session ID that passes all current backend validators:
+//   - Claude: ^[a-zA-Z0-9_-]{1,128}$
+//   - OpenCode: ^ses_[a-zA-Z0-9]{20,40}$
+//   - Codex: any non-empty, non-null string
+const universalResumeID = "ses_abcdefghij1234567890abcd"
+
+// RunBackendTests runs all applicable compliance suites for a [cli.Backend].
+// Optional capabilities ([cli.Resumer], [cli.Streamer], [cli.InputFormatter])
+// are discovered via type assertion — mirroring how the CLIEngine resolves
+// capabilities at Start time.
+func RunBackendTests(t *testing.T, factory func() cli.Backend) {
+	t.Helper()
+
+	t.Run("Spawner", func(t *testing.T) {
+		RunSpawnerTests(t, func() cli.Spawner { return factory() })
+	})
+	t.Run("Parser", func(t *testing.T) {
+		RunParserTests(t, func() cli.Parser { return factory() })
+	})
+
+	probe := factory()
+	if _, ok := probe.(cli.Resumer); ok {
+		t.Run("Resumer", func(t *testing.T) {
+			RunResumerTests(t, func() cli.Resumer { return factory().(cli.Resumer) })
+		})
+	}
+
+	// Streamer: stub for future use.
+	if _, ok := probe.(cli.Streamer); ok {
+		t.Run("Streamer", func(t *testing.T) {
+			t.Skip("Streamer compliance tests not yet implemented")
+		})
+	}
+
+	// InputFormatter: stub for future use.
+	if _, ok := probe.(cli.InputFormatter); ok {
+		t.Run("InputFormatter", func(t *testing.T) {
+			t.Skip("InputFormatter compliance tests not yet implemented")
+		})
+	}
+}
+
+// RunSpawnerTests tests the [cli.Spawner] behavioral contract.
+// The factory is called once per subtest to ensure fresh backend state.
+func RunSpawnerTests(t *testing.T, factory func() cli.Spawner) {
+	t.Helper()
+	runSpawnerStructural(t, factory)
+	runSpawnerSafety(t, factory)
+}
+
+// runSpawnerStructural tests structural invariants: non-empty binary, non-nil args.
+func runSpawnerStructural(t *testing.T, factory func() cli.Spawner) {
+	t.Helper()
+
+	t.Run("ZeroSession", func(t *testing.T) {
+		s := factory()
+		binary, args := s.SpawnArgs(agentrun.Session{})
+		if binary == "" {
+			t.Error("binary must be non-empty")
+		}
+		if args == nil {
+			t.Error("args must be non-nil")
+		}
+	})
+
+	t.Run("BinaryNonEmpty", func(t *testing.T) {
+		s := factory()
+		binary, _ := s.SpawnArgs(agentrun.Session{Prompt: "hello"})
+		if binary == "" {
+			t.Error("binary must be non-empty")
+		}
+	})
+
+	t.Run("BinaryNoNullBytes", func(t *testing.T) {
+		s := factory()
+		binary, _ := s.SpawnArgs(agentrun.Session{Prompt: "hello"})
+		if strings.Contains(binary, "\x00") {
+			t.Error("binary must not contain null bytes")
+		}
+	})
+
+	t.Run("ArgsNonNil", func(t *testing.T) {
+		s := factory()
+		_, args := s.SpawnArgs(agentrun.Session{Prompt: "hello"})
+		if args == nil {
+			t.Error("args must be non-nil")
+		}
+	})
+}
+
+// runSpawnerSafety tests safety contracts: null-byte defense, leading-dash defense.
+func runSpawnerSafety(t *testing.T, factory func() cli.Spawner) {
+	t.Helper()
+
+	t.Run("NoNullBytesInArgs", func(t *testing.T) {
+		s := factory()
+		_, args := s.SpawnArgs(agentrun.Session{Prompt: "hello", Model: "test-model"})
+		if i, ok := indexNullArg(args); ok {
+			t.Errorf("args[%d] contains null bytes", i)
+		}
+	})
+
+	t.Run("NullBytePromptExcluded", func(t *testing.T) {
+		s := factory()
+		_, args := s.SpawnArgs(agentrun.Session{Prompt: "hello\x00world"})
+		if containsArg(args, "hello\x00world") {
+			t.Error("null-byte prompt must not appear in args")
+		}
+	})
+
+	t.Run("NullByteModelExcluded", func(t *testing.T) {
+		s := factory()
+		_, args := s.SpawnArgs(agentrun.Session{Prompt: "hello", Model: "gpt\x00evil"})
+		if containsArg(args, "gpt\x00evil") {
+			t.Error("null-byte model must not appear in args")
+		}
+	})
+
+	t.Run("LeadingDashModelExcluded", func(t *testing.T) {
+		s := factory()
+		_, args := s.SpawnArgs(agentrun.Session{Prompt: "hello", Model: "-evil"})
+		if containsArg(args, "-evil") {
+			t.Error("leading-dash model must not appear as a standalone arg")
+		}
+		if containsArg(args, "--model") || containsArg(args, "-m") {
+			t.Error("model flag must be omitted entirely for leading-dash model")
+		}
+	})
+}
+
+// RunParserTests tests the [cli.Parser] behavioral contract.
+// Assertions use [errors.Is] to match how the CLIEngine checks parser results.
+// The factory is called once per subtest to ensure fresh backend state.
+func RunParserTests(t *testing.T, factory func() cli.Parser) {
+	t.Helper()
+	runParserErrors(t, factory)
+	runParserRobustness(t, factory)
+}
+
+// runParserErrors tests error-path semantics: ErrSkipLine vs real errors.
+func runParserErrors(t *testing.T, factory func() cli.Parser) {
+	t.Helper()
+
+	t.Run("EmptyLineReturnsErrSkipLine", func(t *testing.T) {
+		p := factory()
+		_, err := p.ParseLine("")
+		if !errors.Is(err, cli.ErrSkipLine) {
+			t.Errorf("ParseLine(\"\") error = %v, want ErrSkipLine", err)
+		}
+	})
+
+	t.Run("WhitespaceOnlyReturnsErrSkipLine", func(t *testing.T) {
+		p := factory()
+		_, err := p.ParseLine("   ")
+		if !errors.Is(err, cli.ErrSkipLine) {
+			t.Errorf("ParseLine(\"   \") error = %v, want ErrSkipLine", err)
+		}
+	})
+
+	t.Run("InvalidJSONReturnsNonSkipError", func(t *testing.T) {
+		p := factory()
+		_, err := p.ParseLine("not json")
+		if err == nil {
+			t.Error("ParseLine(\"not json\") should return an error")
+		}
+		if errors.Is(err, cli.ErrSkipLine) {
+			t.Error("ParseLine(\"not json\") should return a non-skip error, got ErrSkipLine")
+		}
+	})
+}
+
+// garbageCorpus is a fixed set of adversarial inputs used by robustness tests.
+var garbageCorpus = []string{
+	"\x00",
+	strings.Repeat("x", 65536),
+	"{{{",
+	"\xff\xfe",
+	`{"":null}`,
+	"null",
+	"[]",
+}
+
+// runParserRobustness tests no-panic guarantees and guard invariants.
+func runParserRobustness(t *testing.T, factory func() cli.Parser) {
+	t.Helper()
+
+	t.Run("TypeFieldWrongTypeNoPanic", func(t *testing.T) { //nolint:revive // no assertions — panics are the failure signal
+		_ = t
+		p := factory()
+		for _, input := range []string{`{"type":99}`, `{"type":true}`, `{"type":[]}`} {
+			_, _ = p.ParseLine(input)
+		}
+	})
+
+	t.Run("GarbageNoPanic", func(t *testing.T) { //nolint:revive // no assertions — panics are the failure signal
+		_ = t
+		p := factory()
+		for _, input := range garbageCorpus {
+			_, _ = p.ParseLine(input)
+		}
+	})
+
+	t.Run("ValidMessageHasType", func(t *testing.T) {
+		// Guard invariant: if any input accidentally parses into a
+		// valid Message (nil error, not ErrSkipLine), that message
+		// must have a non-empty Type.
+		p := factory()
+		corpus := make([]string, 0, len(garbageCorpus)+2)
+		corpus = append(corpus, garbageCorpus...)
+		corpus = append(corpus, `{"type":99}`, `{"type":"unknown"}`)
+		for _, input := range corpus {
+			msg, err := p.ParseLine(input)
+			if err == nil && msg.Type == "" {
+				t.Errorf("ParseLine(%q) returned msg with empty Type and nil error", input)
+			}
+		}
+	})
+}
+
+// RunResumerTests tests the [cli.Resumer] behavioral contract.
+// The factory is called once per subtest to ensure fresh backend state.
+func RunResumerTests(t *testing.T, factory func() cli.Resumer) {
+	t.Helper()
+
+	t.Run("NoResumeID", func(t *testing.T) {
+		r := factory()
+		_, _, err := r.ResumeArgs(agentrun.Session{}, "hello")
+		if err == nil {
+			t.Error("ResumeArgs with no resume ID should return an error")
+		}
+	})
+
+	t.Run("NullByteMessage", func(t *testing.T) {
+		r := factory()
+		_, _, err := r.ResumeArgs(agentrun.Session{
+			Options: map[string]string{agentrun.OptionResumeID: universalResumeID},
+		}, "hello\x00world")
+		if err == nil {
+			t.Error("ResumeArgs with null-byte message should return an error")
+		}
+	})
+
+	t.Run("ValidResume", func(t *testing.T) {
+		r := factory()
+		binary, args, err := r.ResumeArgs(agentrun.Session{
+			Options: map[string]string{agentrun.OptionResumeID: universalResumeID},
+		}, "hello")
+		if err != nil {
+			t.Fatalf("ResumeArgs with valid resume ID should not error: %v", err)
+		}
+		if binary == "" {
+			t.Error("binary must be non-empty")
+		}
+		if args == nil {
+			t.Error("args must be non-nil")
+		}
+		if !containsArg(args, universalResumeID) {
+			t.Errorf("args %v must contain resume ID %q", args, universalResumeID)
+		}
+	})
+}
+
+// containsArg reports whether args contains s as an exact element.
+func containsArg(args []string, s string) bool {
+	for _, a := range args {
+		if a == s {
+			return true
+		}
+	}
+	return false
+}
+
+// indexNullArg returns the index of the first arg containing a null byte.
+func indexNullArg(args []string) (int, bool) {
+	for i, a := range args {
+		if strings.Contains(a, "\x00") {
+			return i, true
+		}
+	}
+	return 0, false
+}

--- a/enginetest/clitest/doc.go
+++ b/enginetest/clitest/doc.go
@@ -1,0 +1,23 @@
+// Package clitest provides compliance test suites for [cli.Backend] implementations.
+//
+// Test authors call [RunBackendTests] with a factory function that returns the
+// implementation under test. The suite discovers optional capabilities
+// ([cli.Resumer], [cli.Streamer], [cli.InputFormatter]) via type assertion.
+//
+// Example usage in a backend test file:
+//
+//	package mybackend_test
+//
+//	import (
+//	    "testing"
+//	    "github.com/dmora/agentrun/engine/cli"
+//	    "github.com/dmora/agentrun/engine/cli/mybackend"
+//	    "github.com/dmora/agentrun/enginetest/clitest"
+//	)
+//
+//	func TestCompliance(t *testing.T) {
+//	    clitest.RunBackendTests(t, func() cli.Backend {
+//	        return mybackend.New()
+//	    })
+//	}
+package clitest

--- a/enginetest/doc.go
+++ b/enginetest/doc.go
@@ -1,15 +1,7 @@
-// Package enginetest provides compliance test suites for agentrun Engine and
-// Backend implementations.
+// Package enginetest provides compliance test suites for agentrun implementations.
 //
-// Test authors call the exported Run*Tests functions (e.g., RunSpawnerTests,
-// RunParserTests) with a factory function that returns the implementation under
-// test. This ensures all backends satisfy the same behavioral contract.
+// CLI backend compliance tests live in the clitest sub-package.
+// Root-level Engine/Process compliance is planned for a future release.
 //
-// Example usage in a backend test file:
-//
-//	func TestClaudeBackend(t *testing.T) {
-//	    enginetest.RunSpawnerTests(t, func() cli.Spawner {
-//	        return claude.New()
-//	    })
-//	}
+// See enginetest/clitest for usage examples.
 package enginetest


### PR DESCRIPTION
## Summary

- **enginetest/clitest**: Shared CLI backend compliance tests — `RunBackendTests` discovers capabilities (Resumer, Streamer, InputFormatter) via type assertion, mirroring CLIEngine's `resolveCapabilities`
- **17 subtests per backend**: SpawnerTests (8), ParserTests (6), ResumerTests (3) — null-byte defense, leading-dash defense, ErrSkipLine semantics, no-panic guarantees, positive-path resume
- **Leading-dash model defense**: Added to Claude and OpenCode (was Codex-only) — enables universal `LeadingDashModelExcluded` contract
- **`universalResumeID`**: `ses_abcdefghij1234567890abcd` passes all 3 backend validators for shared positive-path resume test
- **Docs**: CLAUDE.md architecture tree/package table, CONTRIBUTING.md enginetest section rewritten

### Files

| File | Purpose |
|------|---------|
| `enginetest/clitest/clitest.go` (292 lines) | RunBackendTests, RunSpawner/Parser/ResumerTests |
| `enginetest/clitest/doc.go` | Package docs with usage example |
| `engine/cli/{claude,codex,opencode}/compliance_test.go` | One-line integration per backend |
| `engine/cli/claude/claude.go` | +leading-dash defense |
| `engine/cli/opencode/opencode.go` | +leading-dash defense |
| `enginetest/doc.go` | Namespace reservation rewrite |

## Test plan

- [x] `make qa` green (0 lint, 859 tests pass with `-race`, vet, vulncheck)
- [x] All 3 backends: 17 PASS + 2 SKIP (Streamer/InputFormatter stubs for Claude)
- [x] E2E smoke test: Claude, OpenCode, Codex all return `4` for "What is 2+2?"

Closes dmora/dors-orchestrator#68

🤖 Generated with [Claude Code](https://claude.com/claude-code)