### PR TITLE
feat: surface ACP usage_update as MessageContextWindow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ agentrun (interfaces)
 ├── engine/acp/          ← ACP engine: JSON-RPC 2.0 persistent subprocess
 │   ├── conn.go          ← Bidirectional JSON-RPC 2.0 Conn (platform-agnostic)
 │   ├── protocol.go      ← ACP method constants + request/response types
-│   ├── update.go        ← session/update → agentrun.Message mapping
+│   ├── update.go        ← session/update → agentrun.Message mapping (usage_update → MessageContextWindow)
 │   ├── options.go       ← EngineOptions, PermissionHandler, With* functions
 │   ├── engine.go        ← Engine, NewEngine, Validate, Start (!windows)
 │   └── process.go       ← process impl, Send, Stop, emit (!windows)
@@ -99,7 +99,7 @@ agentrun (interfaces)
 | `engine/cli/internal/jsonutil` | Shared JSON extraction helpers (GetString, GetInt, GetMap, ContainsNull) |
 | `engine/cli/internal/optutil` | Shared option resolution + validation (RootOptionsSet, ValidateModeHITL) |
 | `engine/internal/stoputil` | Shared StopReason sanitization (control char rejection, rune-safe truncation) — used by CLI and ACP engines |
-| `engine/acp` | ACP engine: JSON-RPC 2.0 persistent subprocess, multi-turn without MCP cold boot |
+| `engine/acp` | ACP engine: JSON-RPC 2.0 persistent subprocess, multi-turn without MCP cold boot, surfaces usage_update as MessageContextWindow |
 | `engine/api/adk` | Google ADK API engine |
 | `enginetest` | Namespace for compliance test suites (reserved for future root Engine/Process compliance) |
 | `enginetest/clitest` | CLI backend compliance: RunBackendTests discovers capabilities via type assertion, RunSpawner/Parser/ResumerTests |
@@ -123,8 +123,9 @@ agentrun (interfaces)
 - **OptionAddDirs**: Newline-separated absolute paths for additional directory access. Backends apply `filepath.IsAbs` + leading-dash guard per entry. Supported by Claude (`--add-dir`) and Codex (`--add-dir`); OpenCode silently ignores.
 - **RunTurn helper**: `runturn.go` encapsulates concurrent Send+drain pattern. Callers must provide a context with deadline/timeout. Safe for all engine types.
 - **Shared test infrastructure**: `testutil_test.go` contains `mockProcess` — shared across root-package test files.
-- **Usage omitempty semantics**: Existing fields (`InputTokens`, `OutputTokens`) use bare `int` (always serialized, 0 = zero tokens). New fields (`CacheReadTokens`, `CacheWriteTokens`, `ThinkingTokens`, `CostUSD`) use `omitempty` (0 = not reported by this backend). Asymmetry is intentional and documented per-field in godoc. Nil-guard in `extractTokenUsage` checks ALL fields atomically.
+- **Usage omitempty semantics**: Existing fields (`InputTokens`, `OutputTokens`) use bare `int` (always serialized, 0 = zero tokens). New fields (`CacheReadTokens`, `CacheWriteTokens`, `ThinkingTokens`, `CostUSD`, `ContextSizeTokens`, `ContextUsedTokens`) use `omitempty` (0 = not reported by this backend). Asymmetry is intentional and documented per-field in godoc. Nil-guard in Claude CLI's `extractTokenUsage` checks token+cost fields atomically; context window fields (`ContextSizeTokens`, `ContextUsedTokens`) are handled separately by ACP's `parseUsageUpdate`.
 - **StopReason type**: Output vocabulary (open set, no `Valid()` method). Only 3 universal constants in root (`StopEndTurn`, `StopMaxTokens`, `StopToolUse`). Backend-specific values pass through as raw strings. Consumers should handle unknown values gracefully.
 - **StopReason carry-forward**: Claude CLI `result.stop_reason` is null in streaming mode. Real stop_reason arrives in `message_delta` events. Engine readLoop carries it forward via goroutine-local variable (`applyStopReasonCarryForward` in `engine/cli/process.go`). Init resets stale state, result applies (no clobber). Backend stays stateless.
 - **CostUSD**: `float64` matching Claude CLI wire format. Parsers must sanitize NaN/Inf/negative to zero before populating. Documented as approximate (not for billing reconciliation). Pragmatic exception to "2+ backends" rule — cost tracking is a universal orchestrator need.
 - **ErrorCode**: Machine-readable error code on `MessageError`. Format is backend-specific (CLI: string codes like `"rate_limit"`, ACP: exported constants like `acp.ErrCodeToolCallFailed`). Human-readable description stays in `Content`. Sanitized via `errfmt.SanitizeCode` (reject-on-control, 128-byte cap).
+- **MessageContextWindow**: Mid-turn context window fill state. Only `ContextSizeTokens` and `ContextUsedTokens` are meaningful on this message type; other Usage fields are zero and should be ignored. Currently produced by ACP's `usage_update` notification. Cost data intentionally excluded (CostUSD is authoritative only on MessageResult to avoid double-counting).

--- a/agentrun_test.go
+++ b/agentrun_test.go
@@ -144,12 +144,14 @@ func TestMessageJSON_Full(t *testing.T) {
 			Input: json.RawMessage(`{"path":"foo.go"}`),
 		},
 		Usage: &Usage{
-			InputTokens:      100,
-			OutputTokens:     50,
-			CacheReadTokens:  25,
-			CacheWriteTokens: 10,
-			ThinkingTokens:   5,
-			CostUSD:          0.0042,
+			InputTokens:       100,
+			OutputTokens:      50,
+			CacheReadTokens:   25,
+			CacheWriteTokens:  10,
+			ThinkingTokens:    5,
+			CostUSD:           0.0042,
+			ContextSizeTokens: 200000,
+			ContextUsedTokens: 45000,
 		},
 		StopReason: StopEndTurn,
 		ErrorCode:  "rate_limit",
@@ -210,6 +212,12 @@ func TestMessageJSON_Full(t *testing.T) {
 		}
 		if got.Usage.CostUSD != 0.0042 {
 			t.Errorf("CostUSD: want 0.0042, got %f", got.Usage.CostUSD)
+		}
+		if got.Usage.ContextSizeTokens != 200000 {
+			t.Errorf("ContextSizeTokens: want 200000, got %d", got.Usage.ContextSizeTokens)
+		}
+		if got.Usage.ContextUsedTokens != 45000 {
+			t.Errorf("ContextUsedTokens: want 45000, got %d", got.Usage.ContextUsedTokens)
 		}
 	})
 }
@@ -509,7 +517,7 @@ func TestUsage_JSON_OmitemptyNewFields(t *testing.T) {
 	if err := json.Unmarshal(data, &raw); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	for _, key := range []string{"cache_read_tokens", "cache_write_tokens", "thinking_tokens", "cost_usd"} {
+	for _, key := range []string{"cache_read_tokens", "cache_write_tokens", "thinking_tokens", "cost_usd", "context_size_tokens", "context_used_tokens"} {
 		if _, ok := raw[key]; ok {
 			t.Errorf("field %q should be omitted when zero", key)
 		}
@@ -524,12 +532,14 @@ func TestUsage_JSON_OmitemptyNewFields(t *testing.T) {
 
 func TestUsage_JSON_WithAllFields(t *testing.T) {
 	u := Usage{
-		InputTokens:      100,
-		OutputTokens:     50,
-		CacheReadTokens:  25,
-		CacheWriteTokens: 10,
-		ThinkingTokens:   5,
-		CostUSD:          0.0042,
+		InputTokens:       100,
+		OutputTokens:      50,
+		CacheReadTokens:   25,
+		CacheWriteTokens:  10,
+		ThinkingTokens:    5,
+		CostUSD:           0.0042,
+		ContextSizeTokens: 200000,
+		ContextUsedTokens: 45000,
 	}
 	data, err := json.Marshal(u)
 	if err != nil {

--- a/engine/acp/process_test.go
+++ b/engine/acp/process_test.go
@@ -1,0 +1,76 @@
+//go:build !windows
+
+package acp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dmora/agentrun"
+)
+
+// newTestProcess creates a process with a buffered output channel for testing.
+func newTestProcess(t *testing.T) *process {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return &process{
+		output: make(chan agentrun.Message, 1),
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}
+
+// receiveMessage reads one message from the process output channel or fails.
+func receiveMessage(t *testing.T, p *process) agentrun.Message {
+	t.Helper()
+	select {
+	case msg := <-p.output:
+		return msg
+	default:
+		t.Fatal("expected message on output channel")
+		return agentrun.Message{}
+	}
+}
+
+// TestHandlePromptResult_WithUsageNoContextFields verifies that MessageResult
+// from handlePromptResult never populates ContextSizeTokens or ContextUsedTokens.
+// Context window fields belong exclusively on MessageContextWindow
+// (via parseUsageUpdate), not on turn-level MessageResult.
+func TestHandlePromptResult_WithUsageNoContextFields(t *testing.T) {
+	p := newTestProcess(t)
+	result := &promptResult{
+		StopReason: "end_turn",
+		Usage: &acpUsage{
+			InputTokens:  1000,
+			OutputTokens: 200,
+		},
+	}
+	if err := p.handlePromptResult(nil, result); err != nil {
+		t.Fatalf("handlePromptResult: %v", err)
+	}
+	msg := receiveMessage(t, p)
+	if msg.Usage == nil {
+		t.Fatal("expected Usage on MessageResult")
+	}
+	if msg.Usage.ContextSizeTokens != 0 {
+		t.Errorf("ContextSizeTokens = %d, want 0", msg.Usage.ContextSizeTokens)
+	}
+	if msg.Usage.ContextUsedTokens != 0 {
+		t.Errorf("ContextUsedTokens = %d, want 0", msg.Usage.ContextUsedTokens)
+	}
+}
+
+// TestHandlePromptResult_NilUsage verifies that nil promptResult.Usage
+// produces a nil msg.Usage (no zero-value Usage struct).
+func TestHandlePromptResult_NilUsage(t *testing.T) {
+	p := newTestProcess(t)
+	result := &promptResult{StopReason: "end_turn"}
+	if err := p.handlePromptResult(nil, result); err != nil {
+		t.Fatalf("handlePromptResult: %v", err)
+	}
+	msg := receiveMessage(t, p)
+	if msg.Usage != nil {
+		t.Errorf("expected nil Usage when promptResult.Usage is nil, got %+v", msg.Usage)
+	}
+}

--- a/engine/acp/protocol.go
+++ b/engine/acp/protocol.go
@@ -180,6 +180,15 @@ type acpUsage struct {
 	CachedWriteTokens int `json:"cachedWriteTokens,omitempty"`
 }
 
+// --- Usage Update ---
+
+// usageUpdate is the wire type for ACP usage_update notifications.
+// Wire field mapping: size → Usage.ContextSizeTokens, used → Usage.ContextUsedTokens.
+type usageUpdate struct {
+	Size int `json:"size"`
+	Used int `json:"used"`
+}
+
 // --- Updates (notifications from agent) ---
 
 // sessionNotification is the outer envelope for session/update notifications.

--- a/examples/internal/display/display.go
+++ b/examples/internal/display/display.go
@@ -31,11 +31,27 @@ func PrintMessage(msg agentrun.Message) {
 		printError(msg)
 	case agentrun.MessageToolResult:
 		fmt.Printf("[tool]    %s\n", msg.Tool.Name)
+	case agentrun.MessageContextWindow:
+		printContextWindow(msg)
 	case agentrun.MessageSystem, agentrun.MessageEOF:
 		// silent — system status and EOF are infrastructure signals
 	default:
 		fmt.Printf("[%s]  %s\n", msg.Type, msg.Content)
 	}
+}
+
+// printContextWindow prints context window fill state.
+func printContextWindow(msg agentrun.Message) {
+	if msg.Usage == nil {
+		return
+	}
+	u := msg.Usage
+	fmt.Printf("[context]  %d/%d tokens", u.ContextUsedTokens, u.ContextSizeTokens)
+	if u.ContextSizeTokens > 0 {
+		pct := float64(u.ContextUsedTokens) / float64(u.ContextSizeTokens) * 100
+		fmt.Printf(" (%.0f%%)", pct)
+	}
+	fmt.Println()
 }
 
 // printResultDetails prints StopReason and Usage details for result messages.
@@ -95,6 +111,9 @@ func printRawMetadata(msg agentrun.Message) {
 		}
 		if u.CostUSD > 0 {
 			fmt.Printf(" cost=$%.4f", u.CostUSD)
+		}
+		if u.ContextSizeTokens > 0 {
+			fmt.Printf(" ctx=%d/%d", u.ContextUsedTokens, u.ContextSizeTokens)
 		}
 		fmt.Println()
 	}

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -127,7 +127,7 @@ func TestCompleted_PassesNonDelta(t *testing.T) {
 		agentrun.MessageText, agentrun.MessageResult, agentrun.MessageError,
 		agentrun.MessageInit, agentrun.MessageSystem, agentrun.MessageEOF,
 		agentrun.MessageToolUse, agentrun.MessageToolResult,
-		agentrun.MessageThinking,
+		agentrun.MessageThinking, agentrun.MessageContextWindow,
 	}
 	in := make(chan agentrun.Message, len(nonDelta))
 	go func() {
@@ -170,13 +170,14 @@ func TestCompleted_EmptyInput(t *testing.T) {
 // --- ResultOnly tests ---
 
 func TestResultOnly_PassesOnlyResult(t *testing.T) {
-	in := make(chan agentrun.Message, 5)
+	in := make(chan agentrun.Message, 6)
 	go fill(in,
 		msg(agentrun.MessageTextDelta),
 		msg(agentrun.MessageText),
 		msg(agentrun.MessageError),
 		msg(agentrun.MessageResult),
 		msg(agentrun.MessageInit),
+		msg(agentrun.MessageContextWindow),
 	)
 
 	out := ResultOnly(context.Background(), in)
@@ -232,6 +233,7 @@ func TestIsDelta(t *testing.T) {
 		{agentrun.MessageToolUse, false},
 		{agentrun.MessageToolResult, false},
 		{agentrun.MessageThinking, false},
+		{agentrun.MessageContextWindow, false},
 	}
 	for _, tt := range tests {
 		t.Run(string(tt.mt), func(t *testing.T) {

--- a/message.go
+++ b/message.go
@@ -32,6 +32,17 @@ const (
 	// Token usage and cost data are in Message.Usage.
 	MessageResult MessageType = "result"
 
+	// MessageContextWindow carries context window fill state emitted mid-turn.
+	// Contains window capacity and current fill level. Not all backends emit
+	// this type; it is currently produced by ACP's usage_update notification.
+	//
+	// Only ContextSizeTokens and ContextUsedTokens are meaningful on this
+	// message type. Other Usage fields (InputTokens, OutputTokens, CostUSD,
+	// etc.) are zero and should be ignored — they belong on MessageResult.
+	// Cost data is NOT included — CostUSD is authoritative only on
+	// MessageResult to avoid double-counting.
+	MessageContextWindow MessageType = "context_window"
+
 	// MessageEOF signals the end of the message stream.
 	MessageEOF MessageType = "eof"
 
@@ -186,4 +197,14 @@ type Usage struct {
 	// must sanitize NaN/Inf to zero before populating this field.
 	// Approximate — not suitable for billing reconciliation.
 	CostUSD float64 `json:"cost_usd,omitempty"`
+
+	// ContextSizeTokens is the total context window capacity in tokens.
+	// Omitted when zero (0 means not reported by this backend).
+	// Set on MessageContextWindow messages (ACP usage_update).
+	ContextSizeTokens int `json:"context_size_tokens,omitempty"`
+
+	// ContextUsedTokens is the current context window fill level in tokens.
+	// Omitted when zero (0 means not reported by this backend).
+	// Set on MessageContextWindow messages (ACP usage_update).
+	ContextUsedTokens int `json:"context_used_tokens,omitempty"`
 }


### PR DESCRIPTION
## Summary

- Add `MessageContextWindow` message type + `ContextSizeTokens`/`ContextUsedTokens` fields on `Usage`
- ACP's `usage_update` notification — previously silently consumed — now surfaces as mid-turn context window fill state for orchestrators
- Sanitization: negative→0, size==0→nil, used>size→clamped. CostUSD intentionally excluded (authoritative only on `MessageResult`)

## Changes

| File | Change |
|------|--------|
| `message.go` | `MessageContextWindow` constant + `ContextSizeTokens`/`ContextUsedTokens` on Usage |
| `engine/acp/protocol.go` | `usageUpdate` wire type |
| `engine/acp/update.go` | Replace silent `parseUsageUpdate` with full parser + sanitization |
| `engine/acp/process.go` | Update stale comments (silent consumption → context field exclusion) |
| `engine/acp/update_test.go` | 8 subtests: normal, fresh_session, no_cost, nil cases, clamping, malformed JSON |
| `engine/acp/process_test.go` | `handlePromptResult` contract: context fields never leak to `MessageResult` |
| `filter/filter_test.go` | `MessageContextWindow` in non-delta + IsDelta + ResultOnly tables |
| `agentrun_test.go` | Usage JSON round-trip for new fields |
| `examples/internal/display/display.go` | `printContextWindow` + `printRawMetadata` context output |
| `CLAUDE.md` | Updated docs |

## Test plan

- [x] `make qa` passes (0 lint, all tests with `-race`, vet, vulncheck, examples build)
- [x] Two rounds of 9-agent parallel review — all HIGH findings addressed
- [x] ACP: 127 tests + fuzz, total: 1050+ tests


🤖 Generated with [Claude Code](https://claude.com/claude-code)