### PR TITLE
feat: add IsError field to Message

### DIFF
--- a/engine/cli/claude/parse.go
+++ b/engine/cli/claude/parse.go
@@ -198,9 +198,7 @@ func parseResultMessage(raw map[string]any, msg *agentrun.Message) {
 		msg.StopReason = stoputil.Sanitize(sr)
 	}
 	msg.Denials = extractPermissionDenials(raw)
-	if isErr, ok := raw["is_error"].(bool); ok && isErr {
-		msg.IsError = true
-	}
+	msg.IsError, _ = raw["is_error"].(bool)
 }
 
 // parseErrorMessage handles "error" events.

--- a/engine/cli/claude/parse.go
+++ b/engine/cli/claude/parse.go
@@ -198,6 +198,9 @@ func parseResultMessage(raw map[string]any, msg *agentrun.Message) {
 		msg.StopReason = stoputil.Sanitize(sr)
 	}
 	msg.Denials = extractPermissionDenials(raw)
+	if isErr, ok := raw["is_error"].(bool); ok && isErr {
+		msg.IsError = true
+	}
 }
 
 // parseErrorMessage handles "error" events.

--- a/engine/cli/claude/parse_test.go
+++ b/engine/cli/claude/parse_test.go
@@ -1094,6 +1094,50 @@ func TestParseLine_ResultDenialsWithStopReason(t *testing.T) {
 	}
 }
 
+// --- is_error parse tests ---
+
+func TestParseLine_ResultWithIsErrorTrue(t *testing.T) {
+	b := New()
+	line := `{"type":"result","is_error":true,"result":"Prompt is too long","usage":{"input_tokens":100,"output_tokens":0}}`
+	msg, err := b.ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.Type != agentrun.MessageResult {
+		t.Errorf("type = %q, want %q", msg.Type, agentrun.MessageResult)
+	}
+	if !msg.IsError {
+		t.Error("IsError should be true")
+	}
+	if msg.Content != "Prompt is too long" {
+		t.Errorf("Content = %q, want %q", msg.Content, "Prompt is too long")
+	}
+}
+
+func TestParseLine_ResultWithIsErrorFalse(t *testing.T) {
+	b := New()
+	line := `{"type":"result","is_error":false,"result":"ok","usage":{"input_tokens":10,"output_tokens":5}}`
+	msg, err := b.ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.IsError {
+		t.Error("IsError should be false when is_error is false")
+	}
+}
+
+func TestParseLine_ResultWithIsErrorAbsent(t *testing.T) {
+	b := New()
+	line := `{"type":"result","result":"ok","usage":{"input_tokens":10,"output_tokens":5}}`
+	msg, err := b.ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.IsError {
+		t.Error("IsError should be false when is_error field is absent")
+	}
+}
+
 // --- Fuzz test ---
 
 func FuzzParseLine(f *testing.F) {

--- a/engine/cli/claude/parse_test.go
+++ b/engine/cli/claude/parse_test.go
@@ -1096,45 +1096,48 @@ func TestParseLine_ResultDenialsWithStopReason(t *testing.T) {
 
 // --- is_error parse tests ---
 
-func TestParseLine_ResultWithIsErrorTrue(t *testing.T) {
-	b := New()
-	line := `{"type":"result","is_error":true,"result":"Prompt is too long","usage":{"input_tokens":100,"output_tokens":0}}`
-	msg, err := b.ParseLine(line)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func TestParseLine_ResultIsError(t *testing.T) {
+	tests := []struct {
+		name        string
+		line        string
+		wantIsError bool
+		wantContent string
+	}{
+		{
+			name:        "is_error true",
+			line:        `{"type":"result","is_error":true,"result":"Prompt is too long","usage":{"input_tokens":100,"output_tokens":0}}`,
+			wantIsError: true,
+			wantContent: "Prompt is too long",
+		},
+		{
+			name:        "is_error false",
+			line:        `{"type":"result","is_error":false,"result":"ok","usage":{"input_tokens":10,"output_tokens":5}}`,
+			wantIsError: false,
+		},
+		{
+			name:        "is_error absent",
+			line:        `{"type":"result","result":"ok","usage":{"input_tokens":10,"output_tokens":5}}`,
+			wantIsError: false,
+		},
 	}
-	if msg.Type != agentrun.MessageResult {
-		t.Errorf("type = %q, want %q", msg.Type, agentrun.MessageResult)
-	}
-	if !msg.IsError {
-		t.Error("IsError should be true")
-	}
-	if msg.Content != "Prompt is too long" {
-		t.Errorf("Content = %q, want %q", msg.Content, "Prompt is too long")
-	}
-}
 
-func TestParseLine_ResultWithIsErrorFalse(t *testing.T) {
 	b := New()
-	line := `{"type":"result","is_error":false,"result":"ok","usage":{"input_tokens":10,"output_tokens":5}}`
-	msg, err := b.ParseLine(line)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if msg.IsError {
-		t.Error("IsError should be false when is_error is false")
-	}
-}
-
-func TestParseLine_ResultWithIsErrorAbsent(t *testing.T) {
-	b := New()
-	line := `{"type":"result","result":"ok","usage":{"input_tokens":10,"output_tokens":5}}`
-	msg, err := b.ParseLine(line)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if msg.IsError {
-		t.Error("IsError should be false when is_error field is absent")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, err := b.ParseLine(tt.line)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if msg.Type != agentrun.MessageResult {
+				t.Errorf("type = %q, want %q", msg.Type, agentrun.MessageResult)
+			}
+			if msg.IsError != tt.wantIsError {
+				t.Errorf("IsError = %v, want %v", msg.IsError, tt.wantIsError)
+			}
+			if tt.wantContent != "" && msg.Content != tt.wantContent {
+				t.Errorf("Content = %q, want %q", msg.Content, tt.wantContent)
+			}
+		})
 	}
 }
 

--- a/message.go
+++ b/message.go
@@ -146,6 +146,13 @@ type Message struct {
 	// Nil on all other message types and for API-based engines.
 	Process *ProcessMeta `json:"process,omitempty"`
 
+	// IsError indicates that the result content represents an error condition
+	// reported by the agent itself (e.g., "Prompt is too long"). Set exclusively
+	// on MessageResult messages when the backend's result event includes
+	// is_error: true. When true, Content contains the error description.
+	// Default false means normal completion.
+	IsError bool `json:"is_error,omitempty"`
+
 	// Denials lists tool invocations that were denied during this turn.
 	// Set exclusively on MessageResult messages when one or more tool calls
 	// were blocked by permission controls (e.g., dontAsk mode, HITL rejection).

--- a/message.go
+++ b/message.go
@@ -146,11 +146,11 @@ type Message struct {
 	// Nil on all other message types and for API-based engines.
 	Process *ProcessMeta `json:"process,omitempty"`
 
-	// IsError indicates that the result content represents an error condition
-	// reported by the agent itself (e.g., "Prompt is too long"). Set exclusively
-	// on MessageResult messages when the backend's result event includes
-	// is_error: true. When true, Content contains the error description.
-	// Default false means normal completion.
+	// IsError indicates a result with an agent-level error.
+	// Set exclusively on MessageResult messages when the backend reports
+	// is_error: true.
+	//   - When true: Content contains the error description (e.g., "Prompt is too long").
+	//   - When false (default): normal completion.
 	IsError bool `json:"is_error,omitempty"`
 
 	// Denials lists tool invocations that were denied during this turn.


### PR DESCRIPTION
## Summary
- Add `IsError bool` field to `Message` struct for detecting result errors
- Parse `is_error` from Claude CLI result events in `parseResultMessage()`
- Consumers can now distinguish error results (e.g., "Prompt is too long") from normal results without parsing content text

## Test plan
- [x] `TestParseLine_ResultWithIsErrorTrue` — `is_error: true` → `msg.IsError == true`
- [x] `TestParseLine_ResultWithIsErrorFalse` — `is_error: false` → `msg.IsError == false`
- [x] `TestParseLine_ResultWithIsErrorAbsent` — no `is_error` field → `msg.IsError == false`
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)