### PR TITLE
fix(claude): subagent result must not end the parent turn (#57)

### DIFF
--- a/engine/cli/claude/parse.go
+++ b/engine/cli/claude/parse.go
@@ -65,6 +65,13 @@ func (b *Backend) ParseLine(line string) (agentrun.Message, error) {
 	// Raw JSON is preserved for consumers who need per-subagent usage.
 	if isSubagentEvent(raw) {
 		msg.Usage = nil
+		// A subagent's terminal "result" line must not end the parent turn.
+		// Demote it to MessageSubagentResult so drainOutput waits for the
+		// parent's own result (see issue #57). Only the parent's result
+		// (no parent_tool_use_id) reaches parseResultMessage as MessageResult.
+		if msg.Type == agentrun.MessageResult {
+			msg.Type = agentrun.MessageSubagentResult
+		}
 	}
 
 	return msg, nil

--- a/engine/cli/claude/parse.go
+++ b/engine/cli/claude/parse.go
@@ -71,6 +71,14 @@ func (b *Backend) ParseLine(line string) (agentrun.Message, error) {
 		// (no parent_tool_use_id) reaches parseResultMessage as MessageResult.
 		if msg.Type == agentrun.MessageResult {
 			msg.Type = agentrun.MessageSubagentResult
+			// Strip the result-only fields parseResultMessage populated: a
+			// subagent's stop reason, error flag, and denials describe the
+			// subagent, not the parent turn. Leaving StopReason set is the
+			// worst offender — the engine's carry-forward would capture it
+			// and apply it to the parent's real MessageResult (see PR #58).
+			msg.StopReason = ""
+			msg.IsError = false
+			msg.Denials = nil
 		}
 	}
 

--- a/engine/cli/claude/parse_test.go
+++ b/engine/cli/claude/parse_test.go
@@ -1254,9 +1254,12 @@ func TestParseLine_SubagentResultUsageNilledOut(t *testing.T) {
 	// Subagent result event (parent_tool_use_id set): the common case for any
 	// station that spawns a Task/Explore subagent. It must be demoted to a
 	// non-terminating MessageSubagentResult so it cannot end the parent turn
-	// (issue #57), and its Usage must be dropped so it does not inflate the
-	// parent's context-fill tracking.
-	line := `{"type":"result","result":"done","usage":{"input_tokens":500,"output_tokens":200},"parent_tool_use_id":"toolu_abc"}`
+	// (issue #57). Its Usage must be dropped so it does not inflate the parent's
+	// context-fill tracking, and the other result-only fields (StopReason,
+	// IsError, Denials) must be cleared so a subagent's outcome cannot leak onto
+	// the parent turn — StopReason especially, which would otherwise be carried
+	// forward onto the parent's real MessageResult (PR #58).
+	line := `{"type":"result","result":"done","usage":{"input_tokens":500,"output_tokens":200},"stop_reason":"max_tokens","is_error":true,"permission_denials":[{"tool":"x","reason":"y"}],"parent_tool_use_id":"toolu_abc"}`
 	msg, err := b.ParseLine(line)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1266,6 +1269,15 @@ func TestParseLine_SubagentResultUsageNilledOut(t *testing.T) {
 	}
 	if msg.Usage != nil {
 		t.Errorf("subagent result Usage should be nil, got %+v", msg.Usage)
+	}
+	if msg.StopReason != "" {
+		t.Errorf("subagent result StopReason should be cleared, got %q", msg.StopReason)
+	}
+	if msg.IsError {
+		t.Error("subagent result IsError should be cleared, got true")
+	}
+	if len(msg.Denials) != 0 {
+		t.Errorf("subagent result Denials should be cleared, got %+v", msg.Denials)
 	}
 	// Content is preserved so consumers still see the subagent's text.
 	if msg.Content != "done" {

--- a/engine/cli/claude/parse_test.go
+++ b/engine/cli/claude/parse_test.go
@@ -1251,17 +1251,25 @@ func TestParseLine_MissingParentToolUseIDUsagePreserved(t *testing.T) {
 
 func TestParseLine_SubagentResultUsageNilledOut(t *testing.T) {
 	b := New()
-	// Subagent result event — unlikely in practice but defensive.
+	// Subagent result event (parent_tool_use_id set): the common case for any
+	// station that spawns a Task/Explore subagent. It must be demoted to a
+	// non-terminating MessageSubagentResult so it cannot end the parent turn
+	// (issue #57), and its Usage must be dropped so it does not inflate the
+	// parent's context-fill tracking.
 	line := `{"type":"result","result":"done","usage":{"input_tokens":500,"output_tokens":200},"parent_tool_use_id":"toolu_abc"}`
 	msg, err := b.ParseLine(line)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if msg.Type != agentrun.MessageResult {
-		t.Errorf("type = %q, want %q", msg.Type, agentrun.MessageResult)
+	if msg.Type != agentrun.MessageSubagentResult {
+		t.Errorf("type = %q, want %q", msg.Type, agentrun.MessageSubagentResult)
 	}
 	if msg.Usage != nil {
 		t.Errorf("subagent result Usage should be nil, got %+v", msg.Usage)
+	}
+	// Content is preserved so consumers still see the subagent's text.
+	if msg.Content != "done" {
+		t.Errorf("Content = %q, want %q", msg.Content, "done")
 	}
 }
 

--- a/message.go
+++ b/message.go
@@ -34,11 +34,20 @@ const (
 
 	// MessageSubagentResult is the terminal result of a subagent (e.g., the
 	// Task/Explore tool) nested inside the parent turn — NOT the parent turn's
-	// completion. Backends demote a subagent's result line to this type so it
-	// does not terminate the turn: RunTurn/drainOutput stop only on the parent's
-	// own MessageResult. Consumers that watch for turn completion (e.g.,
-	// filter.ResultOnly) should ignore this type; it carries the subagent's
-	// text in Content, with per-subagent detail available in Raw.
+	// completion.
+	//
+	// Backends demote a subagent's result line to this type so it does not
+	// terminate the turn: RunTurn/drainOutput stop only on the parent's own
+	// MessageResult. Consumers that watch for turn completion (e.g.,
+	// filter.ResultOnly) should ignore this type.
+	//
+	// Field semantics on this message:
+	//   - Content: the subagent's result text, preserved.
+	//   - Raw: the original event, for consumers needing per-subagent detail.
+	//   - Usage, StopReason, IsError, Denials: cleared. These describe the
+	//     subagent, not the parent turn, and are dropped so they cannot leak
+	//     into the parent's turn accounting (StopReason in particular would
+	//     otherwise be carried forward onto the parent's real MessageResult).
 	MessageSubagentResult MessageType = "subagent_result"
 
 	// MessageContextWindow carries context window fill state emitted mid-turn.

--- a/message.go
+++ b/message.go
@@ -32,6 +32,15 @@ const (
 	// Token usage and cost data are in Message.Usage.
 	MessageResult MessageType = "result"
 
+	// MessageSubagentResult is the terminal result of a subagent (e.g., the
+	// Task/Explore tool) nested inside the parent turn — NOT the parent turn's
+	// completion. Backends demote a subagent's result line to this type so it
+	// does not terminate the turn: RunTurn/drainOutput stop only on the parent's
+	// own MessageResult. Consumers that watch for turn completion (e.g.,
+	// filter.ResultOnly) should ignore this type; it carries the subagent's
+	// text in Content, with per-subagent detail available in Raw.
+	MessageSubagentResult MessageType = "subagent_result"
+
 	// MessageContextWindow carries context window fill state emitted mid-turn.
 	// Contains window capacity and current fill level.
 	//

--- a/runturn_test.go
+++ b/runturn_test.go
@@ -359,3 +359,68 @@ func TestRunTurn_Sequential_FreshChannel(t *testing.T) {
 		t.Errorf("msgs[0].Content = %q, want %q (should read from fresh channel)", msgs[0].Content, "fresh")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Subagent turn-boundary regression (issue #57)
+// ---------------------------------------------------------------------------
+
+// TestRunTurn_SubagentResultDoesNotEndTurn pins the fix for issue #57 on a
+// persistent (reused-channel) process — the streaming case the bug was reported
+// against. A subagent's terminal line is demoted by the backend to
+// MessageSubagentResult; drainOutput must NOT treat it as turn completion, so
+// RunTurn returns only at the parent's own MessageResult with the full turn
+// drained. It then verifies a subsequent RunTurn on the SAME process sees none
+// of the first turn's messages — proving the premature-return + cross-dispatch
+// bleed described in the issue cannot occur.
+func TestRunTurn_SubagentResultDoesNotEndTurn(t *testing.T) {
+	mp := newMockProcess()
+
+	// Turn 1: narration, then a subagent result (would have ended the turn
+	// early under the bug), then the parent's real deliverable + result.
+	mp.output <- Message{Type: MessageText, Content: "launched an Explore agent"}
+	mp.output <- Message{Type: MessageSubagentResult, Content: "subagent findings"}
+	mp.output <- Message{Type: MessageText, Content: "the real deliverable"}
+	mp.output <- Message{Type: MessageResult, Content: "parent done"}
+
+	var turn1 []Message
+	if err := RunTurn(context.Background(), mp, "dispatch #1", func(msg Message) error {
+		turn1 = append(turn1, msg)
+		return nil
+	}); err != nil {
+		t.Fatalf("turn 1 RunTurn error: %v", err)
+	}
+
+	// (a) The turn drained fully — it did not return at the subagent result.
+	if len(turn1) != 4 {
+		t.Fatalf("turn 1 got %d messages, want 4 (no early return at subagent result): %+v", len(turn1), turn1)
+	}
+	if turn1[1].Type != MessageSubagentResult {
+		t.Errorf("turn1[1].Type = %q, want %q (subagent result must be delivered, not terminating)", turn1[1].Type, MessageSubagentResult)
+	}
+	if turn1[2].Content != "the real deliverable" {
+		t.Errorf("turn1[2].Content = %q, want the parent deliverable", turn1[2].Content)
+	}
+	if last := turn1[len(turn1)-1]; last.Type != MessageResult || last.Content != "parent done" {
+		t.Errorf("turn 1 ended on %+v, want the parent MessageResult", last)
+	}
+
+	// Turn 2: on the SAME persistent process. Under the bug, turn 1 would have
+	// left "the real deliverable"+parent result queued and turn 2 would read
+	// them (cross-dispatch bleed). With the fix, turn 2 sees only its own output.
+	mp.output <- Message{Type: MessageText, Content: "dispatch #2 output"}
+	mp.output <- Message{Type: MessageResult, Content: "second done"}
+
+	var turn2 []Message
+	if err := RunTurn(context.Background(), mp, "dispatch #2", func(msg Message) error {
+		turn2 = append(turn2, msg)
+		return nil
+	}); err != nil {
+		t.Fatalf("turn 2 RunTurn error: %v", err)
+	}
+	if len(turn2) != 2 {
+		t.Fatalf("turn 2 got %d messages, want 2 (no bleed from turn 1): %+v", len(turn2), turn2)
+	}
+	if turn2[0].Content != "dispatch #2 output" {
+		t.Errorf("turn2[0].Content = %q, want %q (turn 1 must not bleed in)", turn2[0].Content, "dispatch #2 output")
+	}
+}


### PR DESCRIPTION
Fixes **#57**.

## The bug
When a station's Claude process spawns a subagent (the `Task`/`Explore` tool), Claude emits the subagent's terminal line as `{"type":"result", …, "parent_tool_use_id":"…"}`. `ParseLine` mapped it to a turn-terminating `MessageResult` (it stripped only `Usage`, kept `Type`), so `drainOutput` returned on the **first** `MessageResult` — ending the parent turn early with partial output. On a persistent streaming process the parent's real post-subagent output (its deliverable + genuine terminal result) then stayed queued in the reused `Output()` channel and bled into the **next** dispatch. Observed live: a plan dispatch returned in 58s with narration only, and the next dispatch returned its real deliverable in 33ms.

## The fix
Demote a subagent `result` at the parse layer to a new, non-terminating message type — leaving the `Message` struct untouched:

- **`message.go`** — add `MessageSubagentResult`.
- **`parse.go`** — in the `isSubagentEvent` branch, retype `MessageResult` → `MessageSubagentResult`. Only the parent's own result (no `parent_tool_use_id`) stays `MessageResult`, so it's the sole turn terminator.

A dedicated type (rather than reusing `MessageText` or widening `Message` with a parent field) means the subagent result is **automatically excluded from every `msg.Type == MessageResult` turn-boundary check** in the engine (`drainOutput`, `awaitingResult`, turn-summary attribution, `filter.ResultOnly`) — no other call sites need to change.

### Why no drain barrier
The issue floated a per-dispatch drain barrier as defense-in-depth. It was **deliberately not added**: on spawn-per-turn backends (Codex/OpenCode) `proc.Output()` is a closed channel between turns, so a `select { case <-proc.Output(): default: }` drain would spin at 100% CPU. The parse-layer demotion fixes both symptoms on its own — once `drainOutput` waits for the *actual* parent result, the channel is fully drained at turn end, so nothing can bleed.

## Tests
- **`TestParseLine_SubagentResultUsageNilledOut`** updated to assert the demoted type (its old "unlikely in practice but defensive" comment was exactly the case this bug hit).
- **`TestRunTurn_SubagentResultDoesNotEndTurn`** (new) — on a persistent reused-channel process: proves a mid-stream subagent result does not end the turn (the full turn drains to the parent's own result), and that a second `RunTurn` on the same process sees none of the first turn's output.

## Verification
`go build ./...`, `go vet ./...`, and `go test -race ./...` all green.

---
Root-caused and implemented autonomously via Crucible (research → plan → inspect → build → verify), then independently re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
